### PR TITLE
fix: remove www from faucet link

### DIFF
--- a/docs/get-started/get-testnet-xtz-on-etherlink.mdx
+++ b/docs/get-started/get-testnet-xtz-on-etherlink.mdx
@@ -13,7 +13,7 @@ Follow these steps to connect MetaMask and get XTZ tokens that you can use to pa
 
 1. Install [MetaMask](https://metamask.io/) in your browser.
 
-1. Go to [faucet.etherlink.com](https://www.faucet.etherlink.com/).
+1. Go to [faucet.etherlink.com](https://faucet.etherlink.com/).
 
 1. Under "Get testnet XTZ on Etherlink," click **Switch Network** and approve the request to add a network and switch networks in MetaMask.
 


### PR DESCRIPTION
The current link, https://www.faucet.etherlink.com/, gives an unknown domain error.
The correct link is https://faucet.etherlink.com/
