### PR TITLE
remove it's fair

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -18,12 +18,6 @@ Etherlink is an EVM-compatible layer-2 blockchain powered by [Tezos Smart Rollup
 
 **An ERC-20 transaction costs \$0.01 or less on Etherlink**. Etherlink is built on Tezos Smart Rollups, which are enshrined on the platform, meaning that they are implemented directly on layer 1 of the protocol. However, because Smart Rollups run in their own separate environments, they are not subject to the per-transaction gas fees of layer 1, only small fees when they publish their state to layer 1.
 
-### It's fair
-
-**Etherlink has built-in MEV protection for cheaper transactions.** The encrypted mempool stops MEV searchers from exploiting your transactions for profit at your cost. 
-\
-**Etherlink also implements a decentralized sequencer, providing high availability and resistance to attacks.** If the sequencing fails, users have an option to submit to the L1 directly after a delay.
-
 ***
 
 ## How do I start building on Etherlink?


### PR DESCRIPTION
MEV Protection and decentralized sequencer won't be available at launch, so it shouldn't be in the docs.