### PR TITLE
Convert links to base URL

### DIFF
--- a/docs/get-started/using-your-wallet.mdx
+++ b/docs/get-started/using-your-wallet.mdx
@@ -9,7 +9,7 @@ You can connect any wallet that supports custom EVM networks:
 - [Coinbase Wallet](https://www.coinbase.com/en-gb/learn/wallet/How-to-add-custom-networks-Coinbase-Wallet#:~:text=With%20Coinbase%20Wallet%2C%20EVM%2Dcompatible,added%20as%20a%20custom%20network.)
 - [Trust Wallet](https://community.trustwallet.com/t/how-to-add-a-custom-network-on-the-trust-wallet-mobile-app/626781)
 
-The easiest way to connect your MetaMask wallet to Etherlink is to go to [the faucet](https://faucet.etherlink.com/) and connect as described in [Getting testnet XTZ from the faucet](./on-ramping#getting-testnet-xtz-from-the-faucet).
+The easiest way to connect your MetaMask wallet to Etherlink is to go to [the faucet](https://faucet.etherlink.com/) and connect as described in [Getting testnet XTZ from the faucet](/get-started/on-ramping#getting-testnet-xtz-from-the-faucet).
 
 ## Connecting wallets manually
 

--- a/docs/governance/how-do-i-participate-in-governance.md
+++ b/docs/governance/how-do-i-participate-in-governance.md
@@ -1,6 +1,6 @@
 # How do I participate in governance?
 
-Etherlink bakers can participate in the [Etherlink governance process](./how-is-etherlink-governed) by submitting proposals and voting for them.
+Etherlink bakers can participate in the [Etherlink governance process](/governance/how-is-etherlink-governed) by submitting proposals and voting for them.
 
 The voting power of a baker is the amount of tez that it has staked plus the tez that delegators have delegated to it, also called its _staking balance_.
 

--- a/docs/network/building-kernel.md
+++ b/docs/network/building-kernel.md
@@ -3,7 +3,7 @@ title: Building the Etherlink kernel
 ---
 
 It's not necessary to build Etherlink's kernel.
-You can set the `pre-images-endpoint` field in the Smart Rollup node's configuration file as described in [Running an Etherlink Smart Rollup node](./smart-rollup-nodes).
+You can set the `pre-images-endpoint` field in the Smart Rollup node's configuration file as described in [Running an Etherlink Smart Rollup node](/network/smart-rollup-nodes).
 You can also download the installer kernel here: [installer.hex](/files/installer.hex).
 
 However, if you want to build the kernel yourself, you can use these instructions.

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -6,10 +6,10 @@ The Etherlink EVM nodes are responsible for maintaining a copy of the Etherlink 
 
 ## Prerequisites
 
-- Make sure you understand the interaction between different nodes as described in [Etherlink architecture](./architecture).
-- Run an Etherlink Smart Rollup node as described in [Running an Etherlink Smart Rollup node](./smart-rollup-nodes).
+- Make sure you understand the interaction between different nodes as described in [Etherlink architecture](/network/architecture).
+- Run an Etherlink Smart Rollup node as described in [Running an Etherlink Smart Rollup node](/network/smart-rollup-nodes).
 Public Smart Rollup nodes for Etherlink are not yet available, so you must run your own if you want to participate in the Etherlink network.
-- Get the Etherlink installer kernel (`installer.hex` file), which you can build yourself as described in [Building the Etherlink kernel](./building-kernel) or download here: [installer.hex](/files/installer.hex).
+- Get the Etherlink installer kernel (`installer.hex` file), which you can build yourself as described in [Building the Etherlink kernel](/network/building-kernel) or download here: [installer.hex](/files/installer.hex).
 
 ## Running an Etherlink EVM node
 
@@ -32,7 +32,7 @@ The default is `$HOME/.octez-evm-node`.
 
    This configuration uses the preimages that the Tezos Foundation hosts on a file server on a so-called "preimages endpoint".
    It's safe to use these preimages because the node verifies them.
-   If you don't want to use third-party preimages, you can build the kernel yourself and move the contents of the `wasm_2_0_0/` directory to the local data directory; see [Building the Etherlink kernel](./building-kernel).
+   If you don't want to use third-party preimages, you can build the kernel yourself and move the contents of the `wasm_2_0_0/` directory to the local data directory; see [Building the Etherlink kernel](/network/building-kernel).
    However, in this case, you must manually update this directory with the preimages of every kernel voted by the community and deployed on Etherlink after that.
 
 1. Run this command to start the node with the Etherlink installer kernel that you built or downloaded; change the name of the `installer.hex` file in the command accordingly:

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -12,7 +12,7 @@ The data for the original kernel is stored in separate files called _preimages_.
 
 ## References
 
-Make sure that you understand the interaction between different nodes as described in [Etherlink architecture](./architecture).
+Make sure that you understand the interaction between different nodes as described in [Etherlink architecture](/network/architecture).
 
 For more information about Smart Rollup nodes in general, see [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) on docs.tezos.com and [Smart Rollup Node](https://tezos.gitlab.io/shell/smart_rollup_node.html) in the Octez documentation.
 
@@ -48,7 +48,7 @@ The best place to get the most recent binary files to use with Etherlink is http
 
       This configuration uses the preimages that the Tezos Foundation hosts on a file server on a so-called "preimages endpoint".
       It's safe to use these preimages because the node verifies them.
-      If you don't want to use third-party preimages, you can build the kernel yourself and move the contents of the `wasm_2_0_0/` directory to the local data directory; see [Building the Etherlink kernel](./building-kernel).
+      If you don't want to use third-party preimages, you can build the kernel yourself and move the contents of the `wasm_2_0_0/` directory to the local data directory; see [Building the Etherlink kernel](/network/building-kernel).
       However, in this case, you must manually update this directory with the preimages of every kernel voted by the community and deployed on Etherlink after that.
 
 1. Download the latest snapshot from https://snapshots.eu.tzinit.org/etherlink-mainnet/, which is named `eth-mainnet.snapshot`:
@@ -83,4 +83,4 @@ For example, this query gets the health of the node:
    curl -s http://localhost:8932/health
    ```
 
-Now that you have a Smart Rollup node configured for Etherlink, you can run an Etherlink EVM node, as described in [Running an Etherlink EVM node](./evm-nodes).
+Now that you have a Smart Rollup node configured for Etherlink, you can run an Etherlink EVM node, as described in [Running an Etherlink EVM node](/network/evm-nodes).

--- a/docs/tools/vrf.md
+++ b/docs/tools/vrf.md
@@ -6,6 +6,6 @@ title: 'Verifiable Random Functions'
 A VRF is a cryptographic function that takes a series of inputs, computes them, and produces a pseudorandom output and proof of authenticity that can be verified by anyone.
 :::
 
-[Entropy](https://docs.pyth.network/entropy) is a product from [Pyth](./price-feeds#pyth) allowing developers to quickly and easily generate secure random numbers on the blockchain.
+[Entropy](https://docs.pyth.network/entropy) is a product from [Pyth](/tools/price-feeds#pyth) allowing developers to quickly and easily generate secure random numbers on the blockchain.
 
 Learn more in the [docs](https://docs.pyth.network/entropy/create-your-first-entropy-app) provided.


### PR DESCRIPTION
Currently we have a problem with relative links. To reproduce:

1. Go to https://docs.etherlink.com/governance/how-do-i-participate-in-governance and note that there is no slash at the end of the URL.
2. At the top of the page, click the link "Etherlink governance process" and see that it works.
3. Go back to https://docs.etherlink.com/governance/how-do-i-participate-in-governance.
4. Refresh the page and note that the URL now ends with a slash: https://docs.etherlink.com/governance/how-do-i-participate-in-governance/
5. Click the link again and see that the link is broken because it now goes to https://docs.etherlink.com/governance/how-do-i-participate-in-governance/how-is-etherlink-governed

This PR sets all links to be relative to the baseURL so this doesn't happen.