### PR TITLE
Info on how to provide the files for a new kernel

### DIFF
--- a/docs/governance/how-do-i-participate-in-governance.md
+++ b/docs/governance/how-do-i-participate-in-governance.md
@@ -191,6 +191,13 @@ The command takes these parameters:
 - The address of the Sequencer Committee governance contract
 - `"yea"`, `"nay"`, or `"pass"`, including the double quotes
 
+For example:
+
+```bash
+octez-client transfer 0 from tz1RLPEeMxbJYQBFbXYw8WHdXjeUjnG5ZXNq to KT1FRzozuzFMWLimpFeSdADHTMxzU8KtgCr9 \
+  --entrypoint "vote" --arg "\"yea\""
+```
+
 ### Triggering committee upgrades
 
 After a proposed member wins a vote, any user can trigger the change to the committee by calling the governance contract's `trigger_committee_upgrade` entrypoint:

--- a/docs/governance/how-do-i-participate-in-governance.md
+++ b/docs/governance/how-do-i-participate-in-governance.md
@@ -124,6 +124,7 @@ The command takes these parameters:
 - The address of the Etherlink Smart Rollup; the parameter must include the double quotes
 
 After the new kernel becomes active, bakers must provide their nodes with the preimages for the new kernel to continue to participate in Etherlink.
+They can copy the new preimages into the node data directory without stopping or restarting the node.
 If a node uses a preimages endpoint as described in [Running an Etherlink EVM node](../network/evm-nodes) and [Running an Etherlink Smart Rollup node](../network/smart-rollup-nodes), the node updates automatically.
 
 ## Participating in Sequencer Committee governance

--- a/docs/governance/how-do-i-participate-in-governance.md
+++ b/docs/governance/how-do-i-participate-in-governance.md
@@ -123,7 +123,7 @@ The command takes these parameters:
 - The address of the Etherlink kernel or security governance contract
 - The address of the Etherlink Smart Rollup; the parameter must include the double quotes
 
-After the new kernel becomes active, bakers must upgrade their nodes to it to continue to participate in Etherlink.
+After the new kernel becomes active, bakers must provide their nodes with the preimages for the new kernel to continue to participate in Etherlink.
 If a node uses a preimages endpoint as described in [Running an Etherlink EVM node](../network/evm-nodes) and [Running an Etherlink Smart Rollup node](../network/smart-rollup-nodes), the node updates automatically.
 
 ## Participating in Sequencer Committee governance

--- a/docs/governance/how-do-i-participate-in-governance.md
+++ b/docs/governance/how-do-i-participate-in-governance.md
@@ -123,6 +123,9 @@ The command takes these parameters:
 - The address of the Etherlink kernel or security governance contract
 - The address of the Etherlink Smart Rollup; the parameter must include the double quotes
 
+After the new kernel becomes active, bakers must upgrade their nodes to it to continue to participate in Etherlink.
+If a node uses a preimages endpoint as described in [Running an Etherlink EVM node](../network/evm-nodes) and [Running an Etherlink Smart Rollup node](../network/smart-rollup-nodes), the node updates automatically.
+
 ## Participating in Sequencer Committee governance
 
 Bakers can propose a member for Etherlink's Sequencer Committee, vote for or against proposed members, and trigger the change to committee members.

--- a/docs/governance/how-do-i-participate-in-governance.md
+++ b/docs/governance/how-do-i-participate-in-governance.md
@@ -79,6 +79,9 @@ The command takes these parameters:
 - The address of the Etherlink kernel or security governance contract
 - The hash of the kernel upgrade
 
+The proposer must make the code of the new kernel available for people to evaluate.
+Proposers can make it easier for bakers to upgrade to the new kernel by providing the preimages for the kernel online so nodes can update from them directly.
+
 To upvote a proposed kernel or security update during a Proposal period, call the `upvote_proposal` entrypoint with the same parameters:
 
 ```bash


### PR DESCRIPTION
This page has info about how to provide the hash of a proposed kernel, but for completeness, this PR adds a little info about providing the code of the kernel for people to evaluate and the preimages of the kernel for people to upgrade to.