### PR TITLE
Use Algolia search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,6 +4,26 @@
 const math = require('remark-math');
 const katex = require('rehype-katex');
 
+// script-src causes development builds to fail
+// But unsafe-eval should NOT be in production builds
+// Also, put GTM first because sometimes the ';' in the escaped single quotes causes the browser to think it's the end
+const scriptSrc = process.env.NODE_ENV === 'development' ?
+  `https://*.googletagmanager.com 'self' 'unsafe-inline' 'unsafe-eval'`
+  : `https://*.googletagmanager.com 'self' 'unsafe-inline'`;
+
+const contentSecurityPolicy = `
+default-src 'none';
+base-uri 'self';
+manifest-src 'self';
+script-src ${scriptSrc};
+style-src 'self' 'unsafe-inline';
+font-src 'self';
+img-src 'self' https://*.googletagmanager.com https://*.google-analytics.com data:;
+media-src 'self';
+form-action 'self';
+connect-src 'self' https://*.algolia.net https://*.algolianet.com https://*.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com;
+frame-src https://tezosbot.vercel.app;`;
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Etherlink documentation',
@@ -22,6 +42,16 @@ const config = {
   markdown: {
     mermaid: true,
   },
+
+  headTags: [
+    {
+      tagName: 'meta',
+      attributes: {
+        'http-equiv': 'Content-Security-Policy',
+        content: contentSecurityPolicy,
+      },
+    },
+  ],
 
   themes: ['@docusaurus/theme-mermaid'],
 
@@ -92,7 +122,27 @@ const config = {
           scrollOffset: 0,
         },
       },
-
+      algolia: {
+        // The application ID provided by Algolia
+        appId: process.env.NEXT_PUBLIC_DOCSEARCH_APP_ID || "PM6ZQ764IP",
+        // Public API key: it is safe to commit it
+        apiKey: process.env.NEXT_PUBLIC_DOCSEARCH_API_KEY || "c652d71679eec3859b7064047793bab2",
+        indexName: process.env.NEXT_PUBLIC_DOCSEARCH_INDEX_NAME || "etherlink",
+        // Optional: see doc section below
+        contextualSearch: true,
+        // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
+        // externalUrlRegex: 'external\\.com|domain\\.com',
+        // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
+        // replaceSearchResultPathname: {
+        //   from: '/docs/', // or as RegExp: /\/docs\//
+        //   to: '/',
+        // },
+        // Optional: Algolia search parameters
+        // searchParameters: {},
+        // Optional: path for search page that enabled by default (`false` to disable it)
+        searchPagePath: false,
+        //... other Algolia params
+      },
     }),
   stylesheets: [
     {


### PR DESCRIPTION
Enables search for docs.etherlink.com via an Algolia crawler. The crawler is deployed and active; you can see the search working on the preview build here: https://docs-etherlink-git-algolia-search-trili-tech.vercel.app