### PR TITLE
Fix flexible content width

### DIFF
--- a/docs/tools/price-feeds.md
+++ b/docs/tools/price-feeds.md
@@ -5,9 +5,11 @@ title: 'Price Feeds'
 ## Pyth
 
 [Pyth](https://pyth.network/) offers 400+ pull-based price feeds for Etherlink.
+
 Learn more about integrating Pyth with their [docs](https://docs.pyth.network/price-feeds/use-real-time-data/evm).
 
 ## Redstone
 
 [Redstone](https://redstone.finance/) offers push-based price feeds for Etherlink.
+
 Get started with their [docs](https://docs.redstone.finance/docs/introduction) to learn more.

--- a/docs/tools/price-feeds.md
+++ b/docs/tools/price-feeds.md
@@ -5,11 +5,9 @@ title: 'Price Feeds'
 ## Pyth
 
 [Pyth](https://pyth.network/) offers 400+ pull-based price feeds for Etherlink.
-
 Learn more about integrating Pyth with their [docs](https://docs.pyth.network/price-feeds/use-real-time-data/evm).
 
 ## Redstone
 
 [Redstone](https://redstone.finance/) offers push-based price feeds for Etherlink.
-
 Get started with their [docs](https://docs.redstone.finance/docs/introduction) to learn more.

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -60,12 +60,6 @@
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
-/* Widen sidebar to allow room for long titles and emojis */
-@media (min-width: 997px) {
-  :root {
-    width: fit-content;
-  }
-}
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {


### PR DESCRIPTION
This page is formatted really narrowly because the paragraphs were so short. We can fix it by removing some CSS that was making the widths of things flex.

Before:
![Screenshot 2024-07-08 at 8 43 24 AM](https://github.com/etherlinkcom/docs/assets/6494785/761916f9-4978-4fe2-bbd1-c52b8e564174)

After: 

![Screenshot 2024-07-08 at 8 43 42 AM](https://github.com/etherlinkcom/docs/assets/6494785/6448f217-465c-4d72-a1d1-d70b9767728a)
