### PR TITLE
Remove duplicated info about networks and block explorers

### DIFF
--- a/docs/get-started/network-information.mdx
+++ b/docs/get-started/network-information.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Networks & Public RPC Endpoints'
+title: Network information
 ---
 
 import InlineCopy from '@site/src/components/InlineCopy';

--- a/docs/get-started/using-your-wallet.mdx
+++ b/docs/get-started/using-your-wallet.mdx
@@ -2,8 +2,6 @@
 title: 'Using your Wallet'
 ---
 
-import InlineCopy from '@site/src/components/InlineCopy';
-
 ## Which wallets can I use?
 
 You can connect any wallet that supports custom EVM networks:
@@ -15,24 +13,4 @@ The easiest way to connect your MetaMask wallet to Etherlink is to go to [the fa
 
 ## Connecting wallets manually
 
-Use these parameters in your wallet to connect to Etherlink:
-
-### Mainnet
-
-| Parameter          | Value                                                                                    |
-| ------------------ | ---------------------------------------------------------------------------------------- |
-| Network Name       | `Etherlink Mainnet`                                                                      |
-| RPC URL            | <InlineCopy code="https://node.mainnet.etherlink.com" />                                 |
-| Chain ID           | `42793`                                                                                  |
-| Currency Symbol    | `XTZ`                                                                                    |
-| Block Explorer URL | [https://explorer.etherlink.com](https://explorer.etherlink.com)                         |
-
-### Testnet
-
-| Parameter          | Value                                                                                    |
-| ------------------ | ---------------------------------------------------------------------------------------- |
-| Network Name       | `Etherlink Testnet`                                                                      |
-| RPC URL            | <InlineCopy code="https://node.ghostnet.etherlink.com" />                                |
-| Chain ID           | `128123`                                                                                 |
-| Currency Symbol    | `XTZ`                                                                                    |
-| Block Explorer URL | [https://testnet-explorer.etherlink.com/](https://testnet-explorer.etherlink.com/)       |
+To connect your wallet manually, use the parameters in [Network information](./network-information).

--- a/sidebars.js
+++ b/sidebars.js
@@ -26,18 +26,9 @@ const sidebars = {
       collapsed: false,
       items: [
         'get-started/using-your-wallet',
+        'get-started/network-information',
         'get-started/getting-testnet-tokens',
         'get-started/bridging',
-        {
-          type: 'link',
-          href: 'https://explorer.etherlink.com',
-          label: 'Mainnet block explorer',
-        },
-        {
-          type: 'link',
-          href: 'https://testnet-explorer.etherlink.com/',
-          label: 'Testnet block explorer',
-        },
       ],
     },
     {
@@ -45,7 +36,6 @@ const sidebars = {
       label: 'Building on Etherlink ⛓',
       collapsed: false,
       items: [
-        'building-on-etherlink/networks-and-public-rpc-endpoints',
         'building-on-etherlink/endpoint-support',
         'building-on-etherlink/token-addresses',
         'building-on-etherlink/development-toolkits',

--- a/sidebars.js
+++ b/sidebars.js
@@ -31,7 +31,12 @@ const sidebars = {
         {
           type: 'link',
           href: 'https://explorer.etherlink.com',
-          label: 'Block Explorer',
+          label: 'Mainnet block explorer',
+        },
+        {
+          type: 'link',
+          href: 'https://testnet-explorer.etherlink.com/',
+          label: 'Testnet block explorer',
         },
       ],
     },


### PR DESCRIPTION
Remove the block explorer from the sidebar and create a topic named network information for RPC nodes and links to block explorers.
https://docs-etherlink-git-add-ghostnet-block-explorer-trili-tech.vercel.app/get-started/network-information

It kind of feels like this should be in the Network section in the sidebar, but this is really important info that devs will need asap. I'm open to suggestions here.