### PR TITLE
Use sentence case for titles and headings

### DIFF
--- a/docs/building-on-etherlink/development-toolkits.md
+++ b/docs/building-on-etherlink/development-toolkits.md
@@ -1,5 +1,5 @@
 ---
-title: 'Development toolkits'
+title: Development toolkits
 ---
 
 ## 👷 Hardhat

--- a/docs/building-on-etherlink/development-toolkits.md
+++ b/docs/building-on-etherlink/development-toolkits.md
@@ -37,7 +37,7 @@ module.exports = {
 };
 ```
 
-### Deploying and Verifying Contracts with Hardhat
+### Deploying and verifying contracts with Hardhat
 
 Hardhat offers great guides for [deploying](https://hardhat.org/hardhat-runner/docs/guides/deploying) and [verifying](https://hardhat.org/hardhat-runner/docs/guides/verifying) your contracts. Just make sure to set the network flag appropriately: `--network etherlinkTestnet`
 
@@ -50,7 +50,7 @@ Hardhat offers great guides for [deploying](https://hardhat.org/hardhat-runner/d
 **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.\
 **Chisel**: Fast, utilitarian, and verbose solidity REPL.
 
-### Deploying and Verifying Contracts with Foundry
+### Deploying and verifying contracts with Foundry
 
 For the most up to date information on how to deploy and verify a smart contract, check out the [guide](https://book.getfoundry.sh/forge/deploying) provided by the Foundry team!
 

--- a/docs/building-on-etherlink/development-toolkits.md
+++ b/docs/building-on-etherlink/development-toolkits.md
@@ -1,5 +1,5 @@
 ---
-title: 'Development Toolkits'
+title: 'Development toolkits'
 ---
 
 ## 👷 Hardhat

--- a/docs/building-on-etherlink/endpoint-support.md
+++ b/docs/building-on-etherlink/endpoint-support.md
@@ -108,7 +108,7 @@ Method | Supported | Notes
 [`provider.getBalance`](https://docs.ethers.org/v6/api/providers/#Provider-getBalance) | Yes |
 [`signer.sendTransaction`](https://docs.ethers.org/v6/api/providers/#Signer-sendTransaction) | Yes |
 
-## Additional Information
+## Additional information
 
 |                                      | Comments                                                                                                |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------- |

--- a/docs/building-on-etherlink/endpoint-support.md
+++ b/docs/building-on-etherlink/endpoint-support.md
@@ -1,5 +1,5 @@
 ---
-title: 'Ethereum endpoint support'
+title: Ethereum endpoint support
 ---
 
 Etherlink nodes use [Geth](https://geth.ethereum.org/) to provide access to both standard Ethereum RPC endpoints and Geth-specific RPC endpoints.

--- a/docs/building-on-etherlink/token-addresses.md
+++ b/docs/building-on-etherlink/token-addresses.md
@@ -1,5 +1,5 @@
 ---
-title: 'Token Addresses'
+title: 'Token addresses'
 ---
 
 Click the address to go to the block explorer page for the token.

--- a/docs/building-on-etherlink/token-addresses.md
+++ b/docs/building-on-etherlink/token-addresses.md
@@ -1,5 +1,5 @@
 ---
-title: 'Token addresses'
+title: Token addresses
 ---
 
 Click the address to go to the block explorer page for the token.

--- a/docs/get-started/network-information.mdx
+++ b/docs/get-started/network-information.mdx
@@ -4,10 +4,10 @@ title: Network information
 
 import InlineCopy from '@site/src/components/InlineCopy';
 
-## Etherlink mainnet
+## Etherlink Mainnet
 
 <table><thead><tr><th width="231">Parameter</th><th>Value</th></tr></thead><tbody><tr><td>Network Name</td><td><code>Etherlink Mainnet</code></td></tr><tr><td>RPC URL</td><td><InlineCopy code="https://node.mainnet.etherlink.com" /></td></tr><tr><td>Chain ID</td><td><code>42793</code></td></tr><tr><td>Currency Symbol</td><td><code>XTZ</code></td></tr><tr><td>Block Explorer URL</td><td><a href="https://explorer.etherlink.com">https://explorer.etherlink.com</a></td></tr></tbody></table>
 
-## Etherlink testnet
+## Etherlink testnet (Ghostnet)
 
 <table><thead><tr><th width="231">Parameter</th><th>Value</th></tr></thead><tbody><tr><td>Network Name</td><td><code>Etherlink Testnet</code></td></tr><tr><td>RPC URL</td><td><InlineCopy code="https://node.ghostnet.etherlink.com" /></td></tr><tr><td>Chain ID</td><td><code>128123</code></td></tr><tr><td>Currency Symbol</td><td><code>XTZ</code></td></tr><tr><td>Block Explorer URL</td><td><a href="https://testnet-explorer.etherlink.com/">https://testnet-explorer.etherlink.com/</a></td></tr></tbody></table>

--- a/docs/get-started/using-your-wallet.mdx
+++ b/docs/get-started/using-your-wallet.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Using your wallet'
+title: Using your wallet
 ---
 
 import WalletConnectButton from '@site/src/components/WalletConnectButton';

--- a/docs/governance/how-do-i-participate-in-governance.md
+++ b/docs/governance/how-do-i-participate-in-governance.md
@@ -1,4 +1,6 @@
-# How do I participate in governance?
+---
+title: How do I participate in governance?
+---
 
 Etherlink bakers can participate in the [Etherlink governance process](/governance/how-is-etherlink-governed) by submitting proposals and voting for them.
 

--- a/docs/governance/how-is-etherlink-governed.md
+++ b/docs/governance/how-is-etherlink-governed.md
@@ -1,4 +1,6 @@
-# How is Etherlink governed?
+---
+title: How is Etherlink governed?
+---
 
 Like Tezos, Etherlink has a built-in on-chain mechanism for proposing, selecting, testing, and activating upgrades without the need to hard fork.
 This mechanism makes Etherlink self-amending and empowers Tezos bakers to govern Etherlink’s kernel upgrades, security updates, and sequencer operators.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'What is Etherlink?'
+title: What is Etherlink?
 ---
 
 import Figure from '@site/src/components/Figure';

--- a/docs/resources/etherlink-further-reading.md
+++ b/docs/resources/etherlink-further-reading.md
@@ -1,5 +1,5 @@
 ---
-title: 'Etherlink Further Reading'
+title: 'Etherlink further reading'
 ---
 
 * [EVM Rollups Are Coming to Tezos – Now on Testnet](https://research-development.nomadic-labs.com/evm-tezos-testnet.html) - Nomadic Labs

--- a/docs/resources/etherlink-further-reading.md
+++ b/docs/resources/etherlink-further-reading.md
@@ -1,5 +1,5 @@
 ---
-title: 'Etherlink further reading'
+title: Etherlink further reading
 ---
 
 * [EVM Rollups Are Coming to Tezos – Now on Testnet](https://research-development.nomadic-labs.com/evm-tezos-testnet.html) - Nomadic Labs

--- a/docs/resources/scaling-on-tezos.md
+++ b/docs/resources/scaling-on-tezos.md
@@ -1,5 +1,5 @@
 ---
-title: 'Scaling on Tezos'
+title: Scaling on Tezos
 ---
 
 ## Smart Rollups

--- a/docs/tools/cross-chain-comms.md
+++ b/docs/tools/cross-chain-comms.md
@@ -1,5 +1,5 @@
 ---
-title: 'Cross chain communication'
+title: Cross chain communication
 ---
 
 ## LayerZero

--- a/docs/tools/cross-chain-comms.md
+++ b/docs/tools/cross-chain-comms.md
@@ -1,5 +1,5 @@
 ---
-title: 'Cross Chain Communication'
+title: 'Cross chain communication'
 ---
 
 ## LayerZero

--- a/docs/tools/data-indexers.md
+++ b/docs/tools/data-indexers.md
@@ -1,5 +1,5 @@
 ---
-title: 'Data Indexers'
+title: 'Data indexers'
 ---
 
 ## The Graph

--- a/docs/tools/data-indexers.md
+++ b/docs/tools/data-indexers.md
@@ -1,5 +1,5 @@
 ---
-title: 'Data indexers'
+title: Data indexers
 ---
 
 ## The Graph

--- a/docs/tools/developer-experience.md
+++ b/docs/tools/developer-experience.md
@@ -1,5 +1,5 @@
 ---
-title: 'Developer Experience'
+title: 'Developer experience'
 ---
 
 ## Thirdweb

--- a/docs/tools/developer-experience.md
+++ b/docs/tools/developer-experience.md
@@ -1,5 +1,5 @@
 ---
-title: 'Developer experience'
+title: Developer experience
 ---
 
 ## Thirdweb

--- a/docs/tools/institutions.md
+++ b/docs/tools/institutions.md
@@ -1,5 +1,5 @@
 ---
-title: 'Institutional Tools'
+title: 'Institutional tools'
 ---
 
 ## Fireblocks

--- a/docs/tools/institutions.md
+++ b/docs/tools/institutions.md
@@ -1,5 +1,5 @@
 ---
-title: 'Institutional tools'
+title: Institutional tools
 ---
 
 ## Fireblocks

--- a/docs/tools/node-providers.md
+++ b/docs/tools/node-providers.md
@@ -6,6 +6,6 @@ title: Node providers
 
 [Zeeve](https://www.zeeve.io/) provides public and private RPC endpoints for Etherlink, along with websocket support. They also allow you to launch your own dedicated node in just a few clicks!
 
-### Supported Networks
+### Supported networks
 
 Etherlink Testnet - public RPC: https://etherlink-ghostnet-6lcp5r.zeeve.net/rpc

--- a/docs/tools/node-providers.md
+++ b/docs/tools/node-providers.md
@@ -1,5 +1,5 @@
 ---
-title: 'Node providers'
+title: Node providers
 ---
 
 ## Zeeve

--- a/docs/tools/node-providers.md
+++ b/docs/tools/node-providers.md
@@ -1,5 +1,5 @@
 ---
-title: 'Node Providers'
+title: 'Node providers'
 ---
 
 ## Zeeve

--- a/docs/tools/price-feeds.md
+++ b/docs/tools/price-feeds.md
@@ -1,5 +1,5 @@
 ---
-title: 'Price Feeds'
+title: 'Price feeds'
 ---
 
 ## Pyth

--- a/docs/tools/price-feeds.md
+++ b/docs/tools/price-feeds.md
@@ -1,5 +1,5 @@
 ---
-title: 'Price feeds'
+title: Price feeds
 ---
 
 ## Pyth

--- a/docs/tools/vrf.md
+++ b/docs/tools/vrf.md
@@ -1,5 +1,5 @@
 ---
-title: 'Verifiable random functions'
+title: Verifiable random functions
 ---
 
 :::info Verifiable Random Functions (VRF)

--- a/docs/tools/vrf.md
+++ b/docs/tools/vrf.md
@@ -2,7 +2,7 @@
 title: Verifiable random functions
 ---
 
-:::info Verifiable Random Functions (VRF)
+:::info Verifiable random functions (VRF)
 A VRF is a cryptographic function that takes a series of inputs, computes them, and produces a pseudorandom output and proof of authenticity that can be verified by anyone.
 :::
 

--- a/docs/tools/vrf.md
+++ b/docs/tools/vrf.md
@@ -1,5 +1,5 @@
 ---
-title: 'Verifiable Random Functions'
+title: 'Verifiable random functions'
 ---
 
 :::info Verifiable Random Functions (VRF)

--- a/sidebars.js
+++ b/sidebars.js
@@ -22,7 +22,7 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Get Started 🚀',
+      label: 'Get started 🚀',
       collapsed: false,
       items: [
         'get-started/using-your-wallet',
@@ -78,18 +78,18 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Track Etherlink\'s Progress 🏁',
+      label: 'Track Etherlink\'s progress 🏁',
       collapsed: false,
       items: [
         {
           type: 'link',
           href: 'https://gitlab.com/tezos/tezos/-/tree/master/etherlink',
-          label: 'Etherlink Source Code',
+          label: 'Etherlink source code',
         },
         {
           type: 'link',
           href: 'https://gitlab.com/groups/tezos/-/issues/?sort=created\_date\&state=opened\&search=EVM%20\&first\_page\_size=20',
-          label: 'Etherlink Pull Requests',
+          label: 'Etherlink pull requests',
         },
       ],
     },


### PR DESCRIPTION
- Use sentence case for topic titles and headings
- Make front matter `title` fields consistent
- Get capitalization consistent with docs.tezos.com guidelines