### PR TITLE
This link no longer works

### DIFF
--- a/docs/tools/node-providers.md
+++ b/docs/tools/node-providers.md
@@ -5,7 +5,3 @@ title: Node providers
 ## Zeeve
 
 [Zeeve](https://www.zeeve.io/) provides public and private RPC endpoints for Etherlink, along with websocket support. They also allow you to launch your own dedicated node in just a few clicks!
-
-### Supported networks
-
-Etherlink Testnet - public RPC: https://etherlink-ghostnet-6lcp5r.zeeve.net/rpc


### PR DESCRIPTION
WRT https://github.com/etherlinkcom/docs/issues/94, remove the Zeeve RPC URL that no longer works.