### PR TITLE
For simplicity, call it "testnet," not "Ghostnet"

### DIFF
--- a/docs/building-on-etherlink/endpoint-support.md
+++ b/docs/building-on-etherlink/endpoint-support.md
@@ -92,9 +92,9 @@ For information about these endpoints, see the Geth documentation at https://get
 
 Endpoint | Supported | Notes
 --- | --- | ---
-`debug_traceTransaction` | Partially | Supported on Ghostnet but not Mainnet
+`debug_traceTransaction` | Partially | Supported on testnet but not Mainnet
 `eth_call` | No | Etherlink nodes use the standard Ethereum version of the `eth_call` endpoint instead of the Geth version
-`txpool_content` | Partially | Returns the transaction pool on Ghostnet but always returns an empty pool on Mainnet
+`txpool_content` | Partially | Returns the transaction pool on testnet but always returns an empty pool on Mainnet
 
 ## ethers.js SDK methods
 

--- a/docs/building-on-etherlink/token-addresses.md
+++ b/docs/building-on-etherlink/token-addresses.md
@@ -9,7 +9,7 @@ Click the address to go to the block explorer page for the token.
   <th>Name</th>
   <th>Symbol</th>
   <th>Mainnet address</th>
-  <th>Ghostnet address</th>
+  <th>Testnet address</th>
 </thead>
 <tbody>
 <tr>

--- a/docs/get-started/getting-testnet-tokens.mdx
+++ b/docs/get-started/getting-testnet-tokens.mdx
@@ -2,9 +2,9 @@
 title: Getting testnet tokens
 ---
 
-The Etherlink test network, Ghostnet, has a faucet that provides free tez tokens that you can use to pay transaction fees and test applications on Etherlink.
+The Etherlink test network has a faucet that provides free tez tokens that you can use to pay transaction fees and test applications on Etherlink.
 
-To get tez on Etherlink Ghostnet, follow these steps:
+To get tez on Etherlink testnet, follow these steps:
 
 1. Go to [faucet.etherlink.com](https://faucet.etherlink.com/).
 2. Connect your Ethereum wallet.
@@ -13,4 +13,4 @@ To get tez on Etherlink Ghostnet, follow these steps:
 5. Click **Send 1 XTZ**.
 6. Wait until the button shows that the XTZ tokens have been transferred.
 
-You can also get testnet tez on Tezos Ghostnet and bridge them to Etherlink Ghostnet, as described in [Bridging tokens](/get-started/bridging).
+You can also get testnet tez on Tezos testnet and bridge them to Etherlink testnet, as described in [Bridging tokens](/get-started/bridging).

--- a/docs/get-started/getting-testnet-tokens.mdx
+++ b/docs/get-started/getting-testnet-tokens.mdx
@@ -4,7 +4,7 @@ title: Getting testnet tokens
 
 The Etherlink test network has a faucet that provides free tez tokens that you can use to pay transaction fees and test applications on Etherlink.
 
-To get tez on Etherlink testnet, follow these steps:
+To get tez on Etherlink Testnet, follow these steps:
 
 1. Go to [faucet.etherlink.com](https://faucet.etherlink.com/).
 2. Connect your Ethereum wallet.
@@ -13,4 +13,4 @@ To get tez on Etherlink testnet, follow these steps:
 5. Click **Send 1 XTZ**.
 6. Wait until the button shows that the XTZ tokens have been transferred.
 
-You can also get testnet tez on Tezos testnet and bridge them to Etherlink testnet, as described in [Bridging tokens](/get-started/bridging).
+You can also get testnet tez on Tezos testnet and bridge them to Etherlink Testnet, as described in [Bridging tokens](/get-started/bridging).

--- a/docs/get-started/network-information.mdx
+++ b/docs/get-started/network-information.mdx
@@ -8,6 +8,6 @@ import InlineCopy from '@site/src/components/InlineCopy';
 
 <table><thead><tr><th width="231">Parameter</th><th>Value</th></tr></thead><tbody><tr><td>Network Name</td><td><code>Etherlink Mainnet</code></td></tr><tr><td>RPC URL</td><td><InlineCopy code="https://node.mainnet.etherlink.com" /></td></tr><tr><td>Chain ID</td><td><code>42793</code></td></tr><tr><td>Currency Symbol</td><td><code>XTZ</code></td></tr><tr><td>Block Explorer URL</td><td><a href="https://explorer.etherlink.com">https://explorer.etherlink.com</a></td></tr></tbody></table>
 
-## Etherlink testnet (Ghostnet)
+## Etherlink Testnet (Ghostnet)
 
 <table><thead><tr><th width="231">Parameter</th><th>Value</th></tr></thead><tbody><tr><td>Network Name</td><td><code>Etherlink Testnet</code></td></tr><tr><td>RPC URL</td><td><InlineCopy code="https://node.ghostnet.etherlink.com" /></td></tr><tr><td>Chain ID</td><td><code>128123</code></td></tr><tr><td>Currency Symbol</td><td><code>XTZ</code></td></tr><tr><td>Block Explorer URL</td><td><a href="https://testnet-explorer.etherlink.com/">https://testnet-explorer.etherlink.com/</a></td></tr></tbody></table>

--- a/docs/get-started/using-your-wallet.mdx
+++ b/docs/get-started/using-your-wallet.mdx
@@ -25,7 +25,7 @@ You can also click these buttons:
 <WalletConnectButton network="mainnet" title="Connect to Etherlink Mainnet"/>
 </td>
 <td>
-<WalletConnectButton network="ghostnet" title="Connect to Etherlink testnet"/>
+<WalletConnectButton network="ghostnet" title="Connect to Etherlink Testnet"/>
 </td>
 </tr>
 </tbody>

--- a/docs/get-started/using-your-wallet.mdx
+++ b/docs/get-started/using-your-wallet.mdx
@@ -18,14 +18,14 @@ You can also click these buttons:
 <tbody>
 <tr>
 <th>Mainnet</th>
-<th>Ghostnet</th>
+<th>Testnet</th>
 </tr>
 <tr>
 <td>
 <WalletConnectButton network="mainnet" title="Connect to Etherlink Mainnet"/>
 </td>
 <td>
-<WalletConnectButton network="ghostnet" title="Connect to Etherlink Ghostnet"/>
+<WalletConnectButton network="ghostnet" title="Connect to Etherlink testnet"/>
 </td>
 </tr>
 </tbody>

--- a/docs/governance/how-do-i-participate-in-governance.md
+++ b/docs/governance/how-do-i-participate-in-governance.md
@@ -26,7 +26,7 @@ Sequencer committee | [KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF](https://better-call
 
 ### Testnet governance contracts
 
-These are the governance contracts for the Etherlink Smart Rollup on the testnet (Ghostnet), which has the address [`sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg`](https://ghostnet.tzkt.io/sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg):
+These are the governance contracts for the Etherlink Smart Rollup on Etherlink Testnet (Ghostnet), which has the address [`sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg`](https://ghostnet.tzkt.io/sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg):
 
 Governance contract | Address
 --- | ---

--- a/docs/governance/how-do-i-participate-in-governance.md
+++ b/docs/governance/how-do-i-participate-in-governance.md
@@ -24,9 +24,9 @@ Kernel governance | [KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J](https://better-call.d
 Kernel security governance | [KT1N5MHQW5fkqXkW9GPjRYfn5KwbuYrvsY1g](https://better-call.dev/mainnet/KT1N5MHQW5fkqXkW9GPjRYfn5KwbuYrvsY1g)
 Sequencer committee | [KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF](https://better-call.dev/mainnet/KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF)
 
-### Ghostnet governance contracts
+### Testnet governance contracts
 
-These are the governance contracts for the Etherlink Smart Rollup on Ghostnet, which has the address [`sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg`](https://ghostnet.tzkt.io/sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg):
+These are the governance contracts for the Etherlink Smart Rollup on the testnet (Ghostnet), which has the address [`sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg`](https://ghostnet.tzkt.io/sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg):
 
 Governance contract | Address
 --- | ---


### PR DESCRIPTION
The name "Ghostnet" can be confusing; just call it "Testnet" where possible.