### PR TITLE
Fix code block color for dark mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,7 +119,7 @@ const config = {
         ],
       },
       prism: {
-        theme: require('prism-react-renderer/themes/github'),
+        theme: require('prism-react-renderer/themes/dracula'),
         additionalLanguages: ['solidity'],
       },
       // https://github.com/flexanalytics/plugin-image-zoom

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,7 +119,8 @@ const config = {
         ],
       },
       prism: {
-        theme: require('prism-react-renderer/themes/dracula'),
+        theme: require('prism-react-renderer/themes/github'),
+        darkTheme: require('prism-react-renderer/themes/dracula'),
         additionalLanguages: ['solidity'],
       },
       // https://github.com/flexanalytics/plugin-image-zoom

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -208,11 +208,6 @@ nav.navbar {
   border: 1px solid #2A9660
 }
 
-/* Get code blocks closer to site theme */
-.theme-code-block {
-  --prism-background-color: #EEF9FD!important;
-}
-
 /* Footer with last update time */
 .theme-doc-footer {
   background-color: inherit;


### PR DESCRIPTION
Code blocks are showing up in light mode but should be in dark mode.

Before:

<img width="910" alt="Screenshot 2024-07-15 at 1 27 28 PM" src="https://github.com/user-attachments/assets/cedce4e9-3abe-4f2c-bde9-ebbf1e2c04e4">

After:
<img width="890" alt="Screenshot 2024-07-15 at 1 27 37 PM" src="https://github.com/user-attachments/assets/13fae593-5d65-45bc-9c8e-eab4ae110002">
