### PR TITLE
New URL for testnet explorer

### DIFF
--- a/docs/building-on-etherlink/deploying-contracts.md
+++ b/docs/building-on-etherlink/deploying-contracts.md
@@ -62,4 +62,4 @@ If you used the example contract above, you can call the `greet` entrypoint and 
    ![The result of calling the `greet` entrypoint in the example contract](/img/remix-call-contract.png)
 
 Now the contract is deployed on Etherlink.
-You can look it up on the [Testnet block explorer](https://testnet-explorer.etherlink.com/).
+You can look it up on the [Testnet block explorer](https://testnet.explorer.etherlink.com/).

--- a/docs/building-on-etherlink/development-toolkits.md
+++ b/docs/building-on-etherlink/development-toolkits.md
@@ -28,8 +28,8 @@ module.exports = {
         network: "etherlinkTestnet",
         chainId: 128123,
         urls: {
-          apiURL: "https://testnet-explorer.etherlink.com/api",
-          browserURL: "https://testnet-explorer.etherlink.com"
+          apiURL: "https://testnet.explorer.etherlink.com/api",
+          browserURL: "https://testnet.explorer.etherlink.com"
         }
       },
     ]

--- a/docs/building-on-etherlink/tokens.md
+++ b/docs/building-on-etherlink/tokens.md
@@ -19,37 +19,37 @@ Click the address to go to the block explorer page for the token:
   <td>Wrapped XTZ (see <a href="#wxtz">WXTZ</a> below)</td>
   <td>WXTZ</td>
   <td><a href="https://explorer.etherlink.com/address/0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb" target="_blank">0xc9B...3EAb</a></td>
-  <td><a href="https://testnet-explorer.etherlink.com/address/0xB1Ea698633d57705e93b0E40c1077d46CD6A51d8" target="_blank">0xB1E...51d8</a></td>
+  <td><a href="https://testnet.explorer.etherlink.com/address/0xB1Ea698633d57705e93b0E40c1077d46CD6A51d8" target="_blank">0xB1E...51d8</a></td>
 </tr>
 <tr>
   <td>Etherlink USD</td>
   <td>eUSD</td>
   <td>Coming soon</td>
-  <td><a href="https://testnet-explorer.etherlink.com/address/0x1A71f491fb0Ef77F13F8f6d2a927dd4C969ECe4f" target="_blank">0x1A7...Ce4f</a></td>
+  <td><a href="https://testnet.explorer.etherlink.com/address/0x1A71f491fb0Ef77F13F8f6d2a927dd4C969ECe4f" target="_blank">0x1A7...Ce4f</a></td>
 </tr>
 <tr>
   <td>Tether USD</td>
   <td>USDT</td>
   <td><a href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" target="_blank">0x2C0...fE6a</a></td>
-  <td><a href="https://testnet-explorer.etherlink.com/address/0xD21B917D2f4a4a8E3D12892160BFFd8f4cd72d4F" target="_blank">0xD21...2d4F</a></td>
+  <td><a href="https://testnet.explorer.etherlink.com/address/0xD21B917D2f4a4a8E3D12892160BFFd8f4cd72d4F" target="_blank">0xD21...2d4F</a></td>
 </tr>
 <tr>
   <td>USD Coin</td>
   <td>USDC</td>
   <td><a href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" target="_blank">0x796...00F9</a></td>
-  <td><a href="https://testnet-explorer.etherlink.com/address/0xa7c9092A5D2C3663B7C5F714dbA806d02d62B58a" target="_blank">0xa7c...B58a</a></td>
+  <td><a href="https://testnet.explorer.etherlink.com/address/0xa7c9092A5D2C3663B7C5F714dbA806d02d62B58a" target="_blank">0xa7c...B58a</a></td>
 </tr>
 <tr>
   <td>Wrapped Ether</td>
   <td>WETH</td>
   <td><a href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401" target="_blank">0xfc2...B401</a></td>
-  <td><a href="https://testnet-explorer.etherlink.com/address/0x8DEF68408Bc96553003094180E5C90d9fe5b88C1" target="_blank">0x8DE...88C1</a></td>
+  <td><a href="https://testnet.explorer.etherlink.com/address/0x8DEF68408Bc96553003094180E5C90d9fe5b88C1" target="_blank">0x8DE...88C1</a></td>
 </tr>
 <tr>
   <td>Tezos BTC</td>
   <td>tzBTC</td>
   <td>Coming soon</td>
-  <td><a href="https://testnet-explorer.etherlink.com/address/0x6bDE94725379334b469449f4CF49bCfc85ebFb27" target="_blank">0x6bD...Fb27</a></td>
+  <td><a href="https://testnet.explorer.etherlink.com/address/0x6bDE94725379334b469449f4CF49bCfc85ebFb27" target="_blank">0x6bD...Fb27</a></td>
 </tr>
 <tr>
   <td>Wrapped BTC</td>

--- a/docs/get-started/network-information.mdx
+++ b/docs/get-started/network-information.mdx
@@ -10,4 +10,4 @@ import InlineCopy from '@site/src/components/InlineCopy';
 
 ## Etherlink Testnet (Ghostnet)
 
-<table><thead><tr><th width="231">Parameter</th><th>Value</th></tr></thead><tbody><tr><td>Network Name</td><td><code>Etherlink Testnet</code></td></tr><tr><td>RPC URL</td><td><InlineCopy code="https://node.ghostnet.etherlink.com" /></td></tr><tr><td>Chain ID</td><td><code>128123</code></td></tr><tr><td>Currency Symbol</td><td><code>XTZ</code></td></tr><tr><td>Block Explorer URL</td><td><a href="https://testnet-explorer.etherlink.com/">https://testnet-explorer.etherlink.com/</a></td></tr></tbody></table>
+<table><thead><tr><th width="231">Parameter</th><th>Value</th></tr></thead><tbody><tr><td>Network Name</td><td><code>Etherlink Testnet</code></td></tr><tr><td>RPC URL</td><td><InlineCopy code="https://node.ghostnet.etherlink.com" /></td></tr><tr><td>Chain ID</td><td><code>128123</code></td></tr><tr><td>Currency Symbol</td><td><code>XTZ</code></td></tr><tr><td>Block Explorer URL</td><td><a href="https://testnet.explorer.etherlink.com/">https://testnet.explorer.etherlink.com/</a></td></tr></tbody></table>


### PR DESCRIPTION
It's now https://testnet.explorer.etherlink.com.