### PR TITLE
Make color switcher button appear in dark mode on mobile

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -249,3 +249,10 @@ article a[target="_blank"]:after {
 article table {
   overflow: visible;
 }
+
+/* Fix issue with color switcher button disappearing in mobile dark mode */
+@media (max-width: 996px) {
+  .navbar-sidebar__brand button.clean-btn {
+    color: #FFFFFF;
+  }
+}


### PR DESCRIPTION
Fixes #118.

Preview: https://docs-etherlink-git-mobile-color-switcher-trili-tech.vercel.app/?vercelToolbarCode=nQKpE600S854VEd

I don't know why this is happening, but in dark mode on mobile, the color switcher button becomes invisible:

![Screenshot 2024-07-24 at 3 20 40 PM](https://github.com/user-attachments/assets/3eae0d57-67f5-4d84-9f58-9b83e7a2327b)

This PR forces it to white:

![Screenshot 2024-07-24 at 3 21 23 PM](https://github.com/user-attachments/assets/307bb104-45ed-40bf-95f0-52fda4ce8782)
