### PR TITLE
Fix TOC highlighting in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -66,7 +66,6 @@
   --ifm-font-color-base: #FFFFFF;
   --ifm-link-color: #38FF9C;
   --ifm-navbar-link-color: #38FF9C;
-  --ifm-toc-link-color: #38FF9C;
   --ifm-color-primary: #38FF9C;
   --ifm-color-primary-dark: #21af90;
   --ifm-color-primary-darker: #1fa588;
@@ -175,12 +174,16 @@ nav.navbar {
 [data-theme='dark'] .breadcrumbs__item--active .breadcrumbs__link {
   color: #38FF9C;
 }
-[data-theme='dark'] .table-of-contents__link:hover, .table-of-contents__link:hover code, .table-of-contents__link--active {
-  color: #38FF9C;
-}
-
 [data-theme='light'] .breadcrumbs__item--active .breadcrumbs__link {
   color: #2A9660;
+}
+
+/* Table of contents */
+[data-theme='dark'] .table-of-contents .table-of-contents__link--active {
+  color: #38FF9C;
+}
+[data-theme='dark'] .table-of-contents .table-of-contents__link:not(.table-of-contents__link--active) {
+  color: var(--ifm-font-color-base);
 }
 [data-theme='light'] .table-of-contents__link:hover, .table-of-contents__link:hover code, .table-of-contents__link--active {
   color: #2A9660;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -179,11 +179,8 @@ nav.navbar {
 }
 
 /* Table of contents */
-[data-theme='dark'] .table-of-contents .table-of-contents__link--active {
+[data-theme='dark'] .table-of-contents .table-of-contents__link--active, .table-of-contents .table-of-contents__link:hover {
   color: #38FF9C;
-}
-[data-theme='dark'] .table-of-contents .table-of-contents__link:not(.table-of-contents__link--active) {
-  color: var(--ifm-font-color-base);
 }
 [data-theme='light'] .table-of-contents__link:hover, .table-of-contents__link:hover code, .table-of-contents__link--active {
   color: #2A9660;


### PR DESCRIPTION
In dark mode, the in-page TOC highlighting is backwards; the current section is faded out and the other sections are highlighted. This reverses that in dark mode and does not affect light mode:

Preview: https://docs-etherlink-git-toc-highlighting-trili-tech.vercel.app

Before:
![Screenshot 2024-07-24 at 3 54 17 PM](https://github.com/user-attachments/assets/73d96551-c9ac-487d-a97a-611c297e0934)

After:

![Screenshot 2024-07-24 at 3 53 48 PM](https://github.com/user-attachments/assets/df4c1b57-fb94-42a3-80c3-efefa733fbfb)
