### PR TITLE
Add link to status page on network info page

### DIFF
--- a/docs/get-started/network-information.mdx
+++ b/docs/get-started/network-information.mdx
@@ -4,6 +4,8 @@ title: Network information
 
 import InlineCopy from '@site/src/components/InlineCopy';
 
+For current and historical status information for Etherlink, see https://status.etherlink.com.
+
 ## Etherlink Mainnet
 
 <table><thead><tr><th width="231">Parameter</th><th>Value</th></tr></thead><tbody><tr><td>Network Name</td><td><code>Etherlink Mainnet</code></td></tr><tr><td>RPC URL</td><td><InlineCopy code="https://node.mainnet.etherlink.com" /></td></tr><tr><td>Chain ID</td><td><code>42793</code></td></tr><tr><td>Currency Symbol</td><td><code>XTZ</code></td></tr><tr><td>Block Explorer URL</td><td><a href="https://explorer.etherlink.com">https://explorer.etherlink.com</a></td></tr></tbody></table>


### PR DESCRIPTION
If I can work out how to call the Sentry API we could add a green/red indicator light somewhere.