### PR TITLE
Fix link to tokens

### DIFF
--- a/docs/building-on-etherlink/bridging-wrapped-assets.mdx
+++ b/docs/building-on-etherlink/bridging-wrapped-assets.mdx
@@ -102,7 +102,7 @@ If you have general questions about Etherlink, we welcome you to join the [Ether
 
 ## Token addresses
 
-For the addresses of wrapped tokens on Etherlink, see [Tokens](./tokens).
+For the addresses of wrapped tokens on Etherlink, see [Tokens](tokens).
 
 :::note
 


### PR DESCRIPTION
Why isn't docusaurus catching these?