### PR TITLE
Provide Etherlink addresses on wrapped asset page

### DIFF
--- a/docs/building-on-etherlink/bridging-wrapped-assets.mdx
+++ b/docs/building-on-etherlink/bridging-wrapped-assets.mdx
@@ -124,12 +124,6 @@ This table shows the Etherlink address of tokens that you can bridge in and out 
 <tbody>
 
 <tr>
-  <td>SHIB</td>
-  <td>SHIBA INU</td>
-  <td><InlineCopy href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" code="0xBBD1F50A212357067318a84179892684e1Ac5181">0xBBD...5181</InlineCopy></td>
-</tr>
-
-<tr>
   <td>USDC</td>
   <td>USD Coin</td>
   <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
@@ -142,18 +136,6 @@ This table shows the Etherlink address of tokens that you can bridge in and out 
 </tr>
 
 <tr>
-  <td>WAVAX</td>
-  <td>Wrapped AVAX</td>
-  <td><InlineCopy href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" code="0xe820995cD39B6E09EAa7e4e16337184b4A61B644">0xe82...B644</InlineCopy></td>
-</tr>
-
-<tr>
-  <td>WBNB</td>
-  <td>Wrapped BNB</td>
-  <td><InlineCopy href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" code="0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C">0xaA4...0d8C</InlineCopy></td>
-</tr>
-
-<tr>
   <td>WBTC</td>
   <td>Wrapped BTC</td>
   <td><InlineCopy href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...sd0F</InlineCopy></td>
@@ -163,6 +145,24 @@ This table shows the Etherlink address of tokens that you can bridge in and out 
   <td>WETH</td>
   <td>Wrapped Ether</td>
   <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
+</tr>
+
+<tr>
+  <td>WBNB</td>
+  <td>Wrapped BNB</td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" code="0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C">0xaA4...0d8C</InlineCopy></td>
+</tr>
+
+<tr>
+  <td>WAVAX</td>
+  <td>Wrapped AVAX</td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" code="0xe820995cD39B6E09EAa7e4e16337184b4A61B644">0xe82...B644</InlineCopy></td>
+</tr>
+
+<tr>
+  <td>SHIB</td>
+  <td>SHIBA INU</td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" code="0xBBD1F50A212357067318a84179892684e1Ac5181">0xBBD...5181</InlineCopy></td>
 </tr>
 
 </tbody>
@@ -192,14 +192,14 @@ These tables show the addresses of the equivalent tokens on other networks:
   <td><InlineCopy code="0xdAC17F958D2ee523a2206206994597C13D831ec7" /></td>
 </tr>
 <tr>
-  <td><a href="https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" target="_blank">WETH</a></td>
-  <td>Wrapped Ether</td>
-  <td><InlineCopy code="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" /></td>
-</tr>
-<tr>
   <td><a href="https://etherscan.io/address/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" target="_blank">WBTC</a></td>
   <td>Wrapped BTC</td>
   <td><InlineCopy code="0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" /></td>
+</tr>
+<tr>
+  <td><a href="https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" target="_blank">WETH</a></td>
+  <td>Wrapped Ether</td>
+  <td><InlineCopy code="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" /></td>
 </tr>
 <tr>
   <td><a href="https://etherscan.io/address/0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" target="_blank">SHIB</a></td>
@@ -231,14 +231,14 @@ These tables show the addresses of the equivalent tokens on other networks:
   <td><InlineCopy code="0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" /></td>
 </tr>
 <tr>
-  <td><a href="https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" target="_blank">WETH</a></td>
-  <td>Wrapped Ether</td>
-  <td><InlineCopy code="0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" /></td>
-</tr>
-<tr>
   <td><a href="https://arbiscan.io/address/0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" target="_blank">WBTC</a></td>
   <td>Wrapped BTC</td>
   <td><InlineCopy code="0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" /></td>
+</tr>
+<tr>
+  <td><a href="https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" target="_blank">WETH</a></td>
+  <td>Wrapped Ether</td>
+  <td><InlineCopy code="0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" /></td>
 </tr>
 
 </tbody>

--- a/docs/building-on-etherlink/bridging-wrapped-assets.mdx
+++ b/docs/building-on-etherlink/bridging-wrapped-assets.mdx
@@ -102,8 +102,6 @@ If you have general questions about Etherlink, we welcome you to join the [Ether
 
 ## Token addresses
 
-For the addresses of wrapped tokens on Etherlink, see [Tokens](tokens).
-
 :::note
 
 Not all Etherlink tokens can be bridged in and out of Etherlink.

--- a/docs/building-on-etherlink/bridging-wrapped-assets.mdx
+++ b/docs/building-on-etherlink/bridging-wrapped-assets.mdx
@@ -117,51 +117,51 @@ This table shows the Etherlink address of tokens that you can bridge in and out 
 
 <table>
 <thead>
-  <th>Name</th>
   <th>Symbol</th>
+  <th>Name</th>
   <th>Mainnet address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td>SHIBA INU</td>
   <td>SHIB</td>
+  <td>SHIBA INU</td>
   <td><InlineCopy href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" code="0xBBD1F50A212357067318a84179892684e1Ac5181">0xBBD...5181</InlineCopy></td>
 </tr>
 
 <tr>
-  <td>USD Coin</td>
   <td>USDC</td>
+  <td>USD Coin</td>
   <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
 </tr>
 
 <tr>
-  <td>Tether USD</td>
   <td>USDT</td>
+  <td>Tether USD</td>
   <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A">0x2C0...fE6a</InlineCopy></td>
 </tr>
 
 <tr>
-  <td>Wrapped AVAX</td>
   <td>WAVAX</td>
+  <td>Wrapped AVAX</td>
   <td><InlineCopy href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" code="0xe820995cD39B6E09EAa7e4e16337184b4A61B644">0xe82...B644</InlineCopy></td>
 </tr>
 
 <tr>
-  <td>Wrapped BNB</td>
   <td>WBNB</td>
+  <td>Wrapped BNB</td>
   <td><InlineCopy href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" code="0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C">0xaA4...0d8C</InlineCopy></td>
 </tr>
 
 <tr>
-  <td>Wrapped BTC</td>
   <td>WBTC</td>
+  <td>Wrapped BTC</td>
   <td><InlineCopy href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...sd0F</InlineCopy></td>
 </tr>
 
 <tr>
-  <td>Wrapped Ether</td>
   <td>WETH</td>
+  <td>Wrapped Ether</td>
   <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
 </tr>
 

--- a/docs/building-on-etherlink/bridging-wrapped-assets.mdx
+++ b/docs/building-on-etherlink/bridging-wrapped-assets.mdx
@@ -309,17 +309,17 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tr>
   <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://testnet.bscscan.com/address/0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d" code="0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d">0x8AC...580d</InlineCopy></td>
+  <td><InlineCopy href="https://bscscan.com/address/0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d" code="0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d">0x8ac...580d</InlineCopy></td>
 </tr>
 <tr>
   <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy href="https://testnet.bscscan.com/address/0x55d398326f99059fF775485246999027B3197955" code="0x55d398326f99059fF775485246999027B3197955">0x55d...7955</InlineCopy></td>
+  <td><InlineCopy href="https://bscscan.com/address/0x55d398326f99059ff775485246999027b3197955" code="0x55d398326f99059ff775485246999027b3197955">0x55d...7955</InlineCopy></td>
 </tr>
 <tr>
   <td>WBNB</td>
   <td>Wrapped BNB</td>
-  <td><InlineCopy href="https://testnet.bscscan.com/address/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c" code="0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c">0xbb4...095c</InlineCopy></td>
+  <td><InlineCopy href="https://bscscan.com/token/0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c" code="0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c">0xbb4...095c</InlineCopy></td>
 </tr>
 
 </tbody>

--- a/docs/building-on-etherlink/bridging-wrapped-assets.mdx
+++ b/docs/building-on-etherlink/bridging-wrapped-assets.mdx
@@ -182,29 +182,29 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tbody>
 
 <tr>
-  <td><a href="https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" target="_blank">USDC</a></td>
+  <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy code="0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" /></td>
+  <td><InlineCopy href="https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" code="0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48">0xA0b...eB48</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7" target="_blank">USDT</a></td>
+  <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy code="0xdAC17F958D2ee523a2206206994597C13D831ec7" /></td>
+  <td><InlineCopy href="https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7" code="0xdAC17F958D2ee523a2206206994597C13D831ec7">0xdAC...1ec7</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://etherscan.io/address/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" target="_blank">WBTC</a></td>
+  <td>WBTC</td>
   <td>Wrapped BTC</td>
-  <td><InlineCopy code="0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" /></td>
+  <td><InlineCopy href="https://etherscan.io/address/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" code="0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599">0x226...C599</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" target="_blank">WETH</a></td>
+  <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy code="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" /></td>
+  <td><InlineCopy href="https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" code="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2">0xC02...6Cc2</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://etherscan.io/address/0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" target="_blank">SHIB</a></td>
+  <td>SHIB</td>
   <td>SHIBA INU</td>
-  <td><InlineCopy code="0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" /></td>
+  <td><InlineCopy href="https://etherscan.io/address/0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" code="0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE">0x95a...C4cE</InlineCopy></td>
 </tr>
 
 </tbody>
@@ -221,24 +221,24 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tbody>
 
 <tr>
-  <td><a href="https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831" target="_blank">USDC</a></td>
+  <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy code="0xaf88d065e77c8cC2239327C5EDb3A432268e5831" /></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831" code="0xaf88d065e77c8cC2239327C5EDb3A432268e5831">0xaf8...5831</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://arbiscan.io/address/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" target="_blank">USDT</a></td>
+  <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy code="0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" /></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" code="0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9">0xFd0...Cbb9</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://arbiscan.io/address/0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" target="_blank">WBTC</a></td>
+  <td>WBTC</td>
   <td>Wrapped BTC</td>
-  <td><InlineCopy code="0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" /></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" code="0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f">0x2f2...5B0f</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" target="_blank">WETH</a></td>
+  <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy code="0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" /></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" code="0x82aF49447D8a07e3bd95BD0d56f35241523fBab1">0x82a...Bab1</InlineCopy></td>
 </tr>
 
 </tbody>
@@ -255,14 +255,14 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tbody>
 
 <tr>
-  <td><a href="https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" target="_blank">USDC</a></td>
+  <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy code="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" /></td>
+  <td><InlineCopy href="https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" code="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913">0x833...2913</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://basescan.org/address/0x4200000000000000000000000000000000000006" target="_blank">WETH</a></td>
+  <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy code="0x4200000000000000000000000000000000000006" /></td>
+  <td><InlineCopy href="https://basescan.org/address/0x4200000000000000000000000000000000000006" code="0x4200000000000000000000000000000000000006">0x420...0006</InlineCopy></td>
 </tr>
 
 </tbody>
@@ -279,19 +279,19 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tbody>
 
 <tr>
-  <td><a href="https://optimistic.etherscan.io/address/0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" target="_blank">USDC</a></td>
+  <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy code="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" /></td>
+  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" code="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85">0x0b2...Ff85</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://optimistic.etherscan.io/address/0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" target="_blank">USDT</a></td>
+  <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy code="0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" /></td>
+  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" code="0x94b008aA00579c1307B0EF2c499aD98a8ce58e58">0x94b...8e58</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000006" target="_blank">WETH</a></td>
+  <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy code="0x4200000000000000000000000000000000000006" /></td>
+  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000006" code="0x4200000000000000000000000000000000000006">0x420...0006</InlineCopy></td>
 </tr>
 
 </tbody>
@@ -308,19 +308,19 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tbody>
 
 <tr>
-  <td><a href="https://testnet.bscscan.com/address/0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d" target="_blank">USDC</a></td>
+  <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy code="0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d" /></td>
+  <td><InlineCopy href="https://testnet.bscscan.com/address/0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d" code="0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d">0x8AC...580d</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://testnet.bscscan.com/address/0x55d398326f99059fF775485246999027B3197955" target="_blank">USDT</a></td>
+  <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy code="0x55d398326f99059fF775485246999027B3197955" /></td>
+  <td><InlineCopy href="https://testnet.bscscan.com/address/0x55d398326f99059fF775485246999027B3197955" code="0x55d398326f99059fF775485246999027B3197955">0x55d...7955</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://testnet.bscscan.com/address/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c" target="_blank">WBNB</a></td>
+  <td>WBNB</td>
   <td>Wrapped BNB</td>
-  <td><InlineCopy code="0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c" /></td>
+  <td><InlineCopy href="https://testnet.bscscan.com/address/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c" code="0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c">0xbb4...095c</InlineCopy></td>
 </tr>
 
 </tbody>
@@ -337,19 +337,19 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tbody>
 
 <tr>
-  <td><a href="https://avascan.info/blockchain/c/address/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" target="_blank">USDC</a></td>
+  <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy code="0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" /></td>
+  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" code="0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E">0xB97...8a6E</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://avascan.info/blockchain/c/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" target="_blank">USDT</a></td>
+  <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy code="0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" /></td>
+  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" code="0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7">0x970...A8c7</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://avascan.info/blockchain/c/address/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7" target="_blank">WAVAX</a></td>
+  <td>WAVAX</td>
   <td>Wrapped AVAX</td>
-  <td><InlineCopy code="0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7" /></td>
+  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7" code="0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7">B31f6...66c7</InlineCopy></td>
 </tr>
 
 </tbody>

--- a/docs/building-on-etherlink/bridging-wrapped-assets.mdx
+++ b/docs/building-on-etherlink/bridging-wrapped-assets.mdx
@@ -118,34 +118,40 @@ These tables show the addresses of the equivalent tokens on other networks:
 <thead>
   <th>Symbol</th>
   <th>Name</th>
-  <th>Mainnet address</th>
+  <th>Ethereum address</th>
+  <th>Etherlink address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td><a href="https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" target="_blank">USDC</a></td>
+  <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy code="0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" /></td>
+  <td><InlineCopy href="https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" code="0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48">0xA0b...eB48</InlineCopy></td>
+  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7" target="_blank">USDT</a></td>
+  <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy code="0xdAC17F958D2ee523a2206206994597C13D831ec7" /></td>
+  <td><InlineCopy href="https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7" code="0xdAC17F958D2ee523a2206206994597C13D831ec7">0xdAC...1ec7</InlineCopy></td>
+  <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A">0x2C0...fE6a</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" target="_blank">WETH</a></td>
+  <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy code="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" /></td>
+  <td><InlineCopy href="https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" code="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2">0xC02...6Cc2</InlineCopy></td>
+  <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://etherscan.io/address/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" target="_blank">WBTC</a></td>
+  <td>WBTC</td>
   <td>Wrapped BTC</td>
-  <td><InlineCopy code="0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" /></td>
+  <td><InlineCopy href="https://etherscan.io/address/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" code="0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599">0x226...C599</InlineCopy></td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...sd0F</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://etherscan.io/address/0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" target="_blank">SHIB</a></td>
+  <td>SHIB</td>
   <td>SHIBA INU</td>
-  <td><InlineCopy code="0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" /></td>
+  <td><InlineCopy href="https://etherscan.io/address/0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" code="0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE">0x95a...C4cE</InlineCopy></td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" code="0xBBD1F50A212357067318a84179892684e1Ac5181">0xBBD...5181</InlineCopy></td>
 </tr>
 
 </tbody>
@@ -157,29 +163,34 @@ These tables show the addresses of the equivalent tokens on other networks:
 <thead>
   <th>Name</th>
   <th>Symbol</th>
-  <th>Mainnet address</th>
+  <th>Arbitrum One address</th>
+  <th>Etherlink address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td><a href="https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831" target="_blank">USDC</a></td>
+  <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy code="0xaf88d065e77c8cC2239327C5EDb3A432268e5831" /></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831" code="0xaf88d065e77c8cC2239327C5EDb3A432268e5831">0xaf8...5831</InlineCopy></td>
+  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://arbiscan.io/address/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" target="_blank">USDT</a></td>
+  <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy code="0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" /></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" code="0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9">0xFd0...Cbb9</InlineCopy></td>
+  <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A">0x2C0...fE6a</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" target="_blank">WETH</a></td>
+  <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy code="0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" /></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" code="0x82aF49447D8a07e3bd95BD0d56f35241523fBab1">0x82a...Bab1</InlineCopy></td>
+  <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://arbiscan.io/address/0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" target="_blank">WBTC</a></td>
+  <td>WBTC</td>
   <td>Wrapped BTC</td>
-  <td><InlineCopy code="0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" /></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" code="0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f">0x2f2...5B0f</InlineCopy></td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...sd0F</InlineCopy></td>
 </tr>
 
 </tbody>
@@ -191,19 +202,22 @@ These tables show the addresses of the equivalent tokens on other networks:
 <thead>
   <th>Name</th>
   <th>Symbol</th>
-  <th>Mainnet address</th>
+  <th>Base address</th>
+  <th>Etherlink address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td><a href="https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" target="_blank">USDC</a></td>
+  <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy code="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" /></td>
+  <td><InlineCopy href="https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" code="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913">0x833...2913</InlineCopy></td>
+  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://basescan.org/address/0x4200000000000000000000000000000000000006" target="_blank">WETH</a></td>
+  <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy code="0x4200000000000000000000000000000000000006" /></td>
+  <td><InlineCopy href="https://basescan.org/address/0x4200000000000000000000000000000000000006" code="0x4200000000000000000000000000000000000006">0x420...0006</InlineCopy></td>
+  <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
 </tr>
 
 </tbody>
@@ -215,24 +229,28 @@ These tables show the addresses of the equivalent tokens on other networks:
 <thead>
   <th>Name</th>
   <th>Symbol</th>
-  <th>Mainnet address</th>
+  <th>Optimism address</th>
+  <th>Etherlink address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td><a href="https://optimistic.etherscan.io/address/0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" target="_blank">USDC</a></td>
+  <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy code="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" /></td>
+  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" code="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85">0x0b2...Ff85</InlineCopy></td>
+  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://optimistic.etherscan.io/address/0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" target="_blank">USDT</a></td>
+  <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy code="0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" /></td>
+  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" code="0x94b008aA00579c1307B0EF2c499aD98a8ce58e58">0x94b...8e58</InlineCopy></td>
+  <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A">0x2C0...fE6a</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000006" target="_blank">WETH</a></td>
+  <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy code="0x4200000000000000000000000000000000000006" /></td>
+  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000006" code="0x4200000000000000000000000000000000000006">0x420...0006</InlineCopy></td>
+  <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
 </tr>
 
 </tbody>
@@ -244,24 +262,28 @@ These tables show the addresses of the equivalent tokens on other networks:
 <thead>
   <th>Name</th>
   <th>Symbol</th>
-  <th>Mainnet address</th>
+  <th>BNB chain address</th>
+  <th>Etherlink address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td><a href="https://testnet.bscscan.com/address/0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d" target="_blank">USDC</a></td>
+  <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy code="0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d" /></td>
+  <td><InlineCopy href="https://testnet.bscscan.com/address/0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d" code="0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d">0x8AC...580d</InlineCopy></td>
+  <td><InlineCopy code="0xa7c9092A5D2C3663B7C5F714dbA806d02d62B58a" href="https://testnet.explorer.etherlink.com/address/0xa7c9092A5D2C3663B7C5F714dbA806d02d62B58a">0xa7c...B58a</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://testnet.bscscan.com/address/0x55d398326f99059fF775485246999027B3197955" target="_blank">USDT</a></td>
+  <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy code="0x55d398326f99059fF775485246999027B3197955" /></td>
+  <td><InlineCopy href="https://testnet.bscscan.com/address/0x55d398326f99059fF775485246999027B3197955" code="0x55d398326f99059fF775485246999027B3197955">0x55d...7955</InlineCopy></td>
+  <td><InlineCopy code="0xD21B917D2f4a4a8E3D12892160BFFd8f4cd72d4F" href="https://testnet.explorer.etherlink.com/address/0xD21B917D2f4a4a8E3D12892160BFFd8f4cd72d4F">0xD21...2d4F</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://testnet.bscscan.com/address/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c" target="_blank">WBNB</a></td>
+  <td>WBNB</td>
   <td>Wrapped BNB</td>
-  <td><InlineCopy code="0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c" /></td>
+  <td><InlineCopy href="https://testnet.bscscan.com/address/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c" code="0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c">0xbb4...095c</InlineCopy></td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" code="0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C">0xaA4...0d8C</InlineCopy></td>
 </tr>
 
 </tbody>
@@ -273,24 +295,28 @@ These tables show the addresses of the equivalent tokens on other networks:
 <thead>
   <th>Name</th>
   <th>Symbol</th>
-  <th>Mainnet address</th>
+  <th>Avalanche C-Chain address</th>
+  <th>Etherlink address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td><a href="https://avascan.info/blockchain/c/address/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" target="_blank">USDC</a></td>
+  <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy code="0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" /></td>
+  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" code="0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E">0xB97...8a6E</InlineCopy></td>
+  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://avascan.info/blockchain/c/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" target="_blank">USDT</a></td>
+  <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy code="0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" /></td>
+  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" code="0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7">0x970...A8c7</InlineCopy></td>
+  <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A">0x2C0...fE6a</InlineCopy></td>
 </tr>
 <tr>
-  <td><a href="https://avascan.info/blockchain/c/address/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7" target="_blank">WAVAX</a></td>
+  <td>WAVAX</td>
   <td>Wrapped AVAX</td>
-  <td><InlineCopy code="0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7" /></td>
+  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"code="0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7">0xB31...66c7</InlineCopy></td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" code="0xe820995cD39B6E09EAa7e4e16337184b4A61B644">0xe82...B644</InlineCopy></td>
 </tr>
 
 </tbody>

--- a/docs/building-on-etherlink/bridging-wrapped-assets.mdx
+++ b/docs/building-on-etherlink/bridging-wrapped-assets.mdx
@@ -110,6 +110,65 @@ Not all Etherlink tokens can be bridged in and out of Etherlink.
 
 :::
 
+### Etherlink
+
+This table shows the Etherlink address of tokens that you can bridge in and out of Etherlink:
+
+
+<table>
+<thead>
+  <th>Name</th>
+  <th>Symbol</th>
+  <th>Mainnet address</th>
+</thead>
+<tbody>
+
+<tr>
+  <td>SHIBA INU</td>
+  <td>SHIB</td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" code="0xBBD1F50A212357067318a84179892684e1Ac5181">0xBBD...5181</InlineCopy></td>
+</tr>
+
+<tr>
+  <td>USD Coin</td>
+  <td>USDC</td>
+  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
+</tr>
+
+<tr>
+  <td>Tether USD</td>
+  <td>USDT</td>
+  <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A">0x2C0...fE6a</InlineCopy></td>
+</tr>
+
+<tr>
+  <td>Wrapped AVAX</td>
+  <td>WAVAX</td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" code="0xe820995cD39B6E09EAa7e4e16337184b4A61B644">0xe82...B644</InlineCopy></td>
+</tr>
+
+<tr>
+  <td>Wrapped BNB</td>
+  <td>WBNB</td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" code="0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C">0xaA4...0d8C</InlineCopy></td>
+</tr>
+
+<tr>
+  <td>Wrapped BTC</td>
+  <td>WBTC</td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...sd0F</InlineCopy></td>
+</tr>
+
+<tr>
+  <td>Wrapped Ether</td>
+  <td>WETH</td>
+  <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
+</tr>
+
+</tbody>
+</table>
+
+
 These tables show the addresses of the equivalent tokens on other networks:
 
 ### Ethereum

--- a/docs/building-on-etherlink/bridging-wrapped-assets.mdx
+++ b/docs/building-on-etherlink/bridging-wrapped-assets.mdx
@@ -118,40 +118,34 @@ These tables show the addresses of the equivalent tokens on other networks:
 <thead>
   <th>Symbol</th>
   <th>Name</th>
-  <th>Ethereum address</th>
-  <th>Etherlink address</th>
+  <th>Mainnet address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td>USDC</td>
+  <td><a href="https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" target="_blank">USDC</a></td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" code="0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48">0xA0b...eB48</InlineCopy></td>
-  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
+  <td><InlineCopy code="0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" /></td>
 </tr>
 <tr>
-  <td>USDT</td>
+  <td><a href="https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7" target="_blank">USDT</a></td>
   <td>Tether USD</td>
-  <td><InlineCopy href="https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7" code="0xdAC17F958D2ee523a2206206994597C13D831ec7">0xdAC...1ec7</InlineCopy></td>
-  <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A">0x2C0...fE6a</InlineCopy></td>
+  <td><InlineCopy code="0xdAC17F958D2ee523a2206206994597C13D831ec7" /></td>
 </tr>
 <tr>
-  <td>WETH</td>
+  <td><a href="https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" target="_blank">WETH</a></td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy href="https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" code="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2">0xC02...6Cc2</InlineCopy></td>
-  <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
+  <td><InlineCopy code="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" /></td>
 </tr>
 <tr>
-  <td>WBTC</td>
+  <td><a href="https://etherscan.io/address/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" target="_blank">WBTC</a></td>
   <td>Wrapped BTC</td>
-  <td><InlineCopy href="https://etherscan.io/address/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" code="0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599">0x226...C599</InlineCopy></td>
-  <td><InlineCopy href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...sd0F</InlineCopy></td>
+  <td><InlineCopy code="0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" /></td>
 </tr>
 <tr>
-  <td>SHIB</td>
+  <td><a href="https://etherscan.io/address/0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" target="_blank">SHIB</a></td>
   <td>SHIBA INU</td>
-  <td><InlineCopy href="https://etherscan.io/address/0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" code="0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE">0x95a...C4cE</InlineCopy></td>
-  <td><InlineCopy href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" code="0xBBD1F50A212357067318a84179892684e1Ac5181">0xBBD...5181</InlineCopy></td>
+  <td><InlineCopy code="0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" /></td>
 </tr>
 
 </tbody>
@@ -163,34 +157,29 @@ These tables show the addresses of the equivalent tokens on other networks:
 <thead>
   <th>Name</th>
   <th>Symbol</th>
-  <th>Arbitrum One address</th>
-  <th>Etherlink address</th>
+  <th>Mainnet address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td>USDC</td>
+  <td><a href="https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831" target="_blank">USDC</a></td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831" code="0xaf88d065e77c8cC2239327C5EDb3A432268e5831">0xaf8...5831</InlineCopy></td>
-  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
+  <td><InlineCopy code="0xaf88d065e77c8cC2239327C5EDb3A432268e5831" /></td>
 </tr>
 <tr>
-  <td>USDT</td>
+  <td><a href="https://arbiscan.io/address/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" target="_blank">USDT</a></td>
   <td>Tether USD</td>
-  <td><InlineCopy href="https://arbiscan.io/address/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" code="0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9">0xFd0...Cbb9</InlineCopy></td>
-  <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A">0x2C0...fE6a</InlineCopy></td>
+  <td><InlineCopy code="0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" /></td>
 </tr>
 <tr>
-  <td>WETH</td>
+  <td><a href="https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" target="_blank">WETH</a></td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy href="https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" code="0x82aF49447D8a07e3bd95BD0d56f35241523fBab1">0x82a...Bab1</InlineCopy></td>
-  <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
+  <td><InlineCopy code="0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" /></td>
 </tr>
 <tr>
-  <td>WBTC</td>
+  <td><a href="https://arbiscan.io/address/0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" target="_blank">WBTC</a></td>
   <td>Wrapped BTC</td>
-  <td><InlineCopy href="https://arbiscan.io/address/0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" code="0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f">0x2f2...5B0f</InlineCopy></td>
-  <td><InlineCopy href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...sd0F</InlineCopy></td>
+  <td><InlineCopy code="0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" /></td>
 </tr>
 
 </tbody>
@@ -202,22 +191,19 @@ These tables show the addresses of the equivalent tokens on other networks:
 <thead>
   <th>Name</th>
   <th>Symbol</th>
-  <th>Base address</th>
-  <th>Etherlink address</th>
+  <th>Mainnet address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td>USDC</td>
+  <td><a href="https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" target="_blank">USDC</a></td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" code="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913">0x833...2913</InlineCopy></td>
-  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
+  <td><InlineCopy code="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" /></td>
 </tr>
 <tr>
-  <td>WETH</td>
+  <td><a href="https://basescan.org/address/0x4200000000000000000000000000000000000006" target="_blank">WETH</a></td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy href="https://basescan.org/address/0x4200000000000000000000000000000000000006" code="0x4200000000000000000000000000000000000006">0x420...0006</InlineCopy></td>
-  <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
+  <td><InlineCopy code="0x4200000000000000000000000000000000000006" /></td>
 </tr>
 
 </tbody>
@@ -229,28 +215,24 @@ These tables show the addresses of the equivalent tokens on other networks:
 <thead>
   <th>Name</th>
   <th>Symbol</th>
-  <th>Optimism address</th>
-  <th>Etherlink address</th>
+  <th>Mainnet address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td>USDC</td>
+  <td><a href="https://optimistic.etherscan.io/address/0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" target="_blank">USDC</a></td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" code="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85">0x0b2...Ff85</InlineCopy></td>
-  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
+  <td><InlineCopy code="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" /></td>
 </tr>
 <tr>
-  <td>USDT</td>
+  <td><a href="https://optimistic.etherscan.io/address/0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" target="_blank">USDT</a></td>
   <td>Tether USD</td>
-  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" code="0x94b008aA00579c1307B0EF2c499aD98a8ce58e58">0x94b...8e58</InlineCopy></td>
-  <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A">0x2C0...fE6a</InlineCopy></td>
+  <td><InlineCopy code="0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" /></td>
 </tr>
 <tr>
-  <td>WETH</td>
+  <td><a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000006" target="_blank">WETH</a></td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000006" code="0x4200000000000000000000000000000000000006">0x420...0006</InlineCopy></td>
-  <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
+  <td><InlineCopy code="0x4200000000000000000000000000000000000006" /></td>
 </tr>
 
 </tbody>
@@ -262,28 +244,24 @@ These tables show the addresses of the equivalent tokens on other networks:
 <thead>
   <th>Name</th>
   <th>Symbol</th>
-  <th>BNB chain address</th>
-  <th>Etherlink address</th>
+  <th>Mainnet address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td>USDC</td>
+  <td><a href="https://testnet.bscscan.com/address/0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d" target="_blank">USDC</a></td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://testnet.bscscan.com/address/0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d" code="0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d">0x8AC...580d</InlineCopy></td>
-  <td><InlineCopy code="0xa7c9092A5D2C3663B7C5F714dbA806d02d62B58a" href="https://testnet.explorer.etherlink.com/address/0xa7c9092A5D2C3663B7C5F714dbA806d02d62B58a">0xa7c...B58a</InlineCopy></td>
+  <td><InlineCopy code="0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d" /></td>
 </tr>
 <tr>
-  <td>USDT</td>
+  <td><a href="https://testnet.bscscan.com/address/0x55d398326f99059fF775485246999027B3197955" target="_blank">USDT</a></td>
   <td>Tether USD</td>
-  <td><InlineCopy href="https://testnet.bscscan.com/address/0x55d398326f99059fF775485246999027B3197955" code="0x55d398326f99059fF775485246999027B3197955">0x55d...7955</InlineCopy></td>
-  <td><InlineCopy code="0xD21B917D2f4a4a8E3D12892160BFFd8f4cd72d4F" href="https://testnet.explorer.etherlink.com/address/0xD21B917D2f4a4a8E3D12892160BFFd8f4cd72d4F">0xD21...2d4F</InlineCopy></td>
+  <td><InlineCopy code="0x55d398326f99059fF775485246999027B3197955" /></td>
 </tr>
 <tr>
-  <td>WBNB</td>
+  <td><a href="https://testnet.bscscan.com/address/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c" target="_blank">WBNB</a></td>
   <td>Wrapped BNB</td>
-  <td><InlineCopy href="https://testnet.bscscan.com/address/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c" code="0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c">0xbb4...095c</InlineCopy></td>
-  <td><InlineCopy href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" code="0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C">0xaA4...0d8C</InlineCopy></td>
+  <td><InlineCopy code="0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c" /></td>
 </tr>
 
 </tbody>
@@ -295,28 +273,24 @@ These tables show the addresses of the equivalent tokens on other networks:
 <thead>
   <th>Name</th>
   <th>Symbol</th>
-  <th>Avalanche C-Chain address</th>
-  <th>Etherlink address</th>
+  <th>Mainnet address</th>
 </thead>
 <tbody>
 
 <tr>
-  <td>USDC</td>
+  <td><a href="https://avascan.info/blockchain/c/address/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" target="_blank">USDC</a></td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" code="0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E">0xB97...8a6E</InlineCopy></td>
-  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
+  <td><InlineCopy code="0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" /></td>
 </tr>
 <tr>
-  <td>USDT</td>
+  <td><a href="https://avascan.info/blockchain/c/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" target="_blank">USDT</a></td>
   <td>Tether USD</td>
-  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" code="0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7">0x970...A8c7</InlineCopy></td>
-  <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A">0x2C0...fE6a</InlineCopy></td>
+  <td><InlineCopy code="0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" /></td>
 </tr>
 <tr>
-  <td>WAVAX</td>
+  <td><a href="https://avascan.info/blockchain/c/address/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7" target="_blank">WAVAX</a></td>
   <td>Wrapped AVAX</td>
-  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"code="0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7">0xB31...66c7</InlineCopy></td>
-  <td><InlineCopy href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" code="0xe820995cD39B6E09EAa7e4e16337184b4A61B644">0xe82...B644</InlineCopy></td>
+  <td><InlineCopy code="0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7" /></td>
 </tr>
 
 </tbody>

--- a/docs/building-on-etherlink/bridging-wrapped-assets.mdx
+++ b/docs/building-on-etherlink/bridging-wrapped-assets.mdx
@@ -105,6 +105,7 @@ If you have general questions about Etherlink, we welcome you to join the [Ether
 :::note
 
 Not all Etherlink tokens can be bridged in and out of Etherlink.
+See the tables below for the tokens that the bridge supports.
 
 :::
 

--- a/docs/building-on-etherlink/tokens.mdx
+++ b/docs/building-on-etherlink/tokens.mdx
@@ -56,25 +56,25 @@ Click the address to go to the block explorer page for the token:
 <tr>
   <td>Wrapped BTC</td>
   <td>WBTC</td>
-  <td><InlineCopy href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...sd0F</InlineCopy></td>
+  <td><a href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" target="_blank">0xbFc...sd0F</a></td>
   <td></td>
 </tr>
 <tr>
   <td>Wrapped BNB</td>
   <td>WBNB</td>
-  <td><InlineCopy href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" code="0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C">0xaA4...0d8C</InlineCopy></td>
+  <td><a href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" target="_blank">0xaA4...0d8C</a></td>
   <td></td>
 </tr>
 <tr>
   <td>Wrapped AVAX</td>
   <td>WAVAX</td>
-  <td><InlineCopy href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" code="0xe820995cD39B6E09EAa7e4e16337184b4A61B644">0xe82...B644</InlineCopy></td>
+  <td><a href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" target="_blank">0xe82...B644</a></td>
   <td></td>
 </tr>
 <tr>
   <td>SHIBA INU</td>
   <td>SHIB</td>
-  <td><InlineCopy href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" code="0xBBD1F50A212357067318a84179892684e1Ac5181">0xBBD...5181</InlineCopy></td>
+  <td><a href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" target="_blank">0xBBD...5181</a></td>
   <td></td>
 </tr>
 </tbody>

--- a/docs/building-on-etherlink/tokens.mdx
+++ b/docs/building-on-etherlink/tokens.mdx
@@ -56,25 +56,25 @@ Click the address to go to the block explorer page for the token:
 <tr>
   <td>Wrapped BTC</td>
   <td>WBTC</td>
-  <td><a href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" target="_blank">0xbFc...sd0F</a></td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...sd0F</InlineCopy></td>
   <td></td>
 </tr>
 <tr>
   <td>Wrapped BNB</td>
   <td>WBNB</td>
-  <td><a href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" target="_blank">0xaA4...0d8C</a></td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" code="0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C">0xaA4...0d8C</InlineCopy></td>
   <td></td>
 </tr>
 <tr>
   <td>Wrapped AVAX</td>
   <td>WAVAX</td>
-  <td><a href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" target="_blank">0xe82...B644</a></td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" code="0xe820995cD39B6E09EAa7e4e16337184b4A61B644">0xe82...B644</InlineCopy></td>
   <td></td>
 </tr>
 <tr>
   <td>SHIBA INU</td>
   <td>SHIB</td>
-  <td><a href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" target="_blank">0xBBD...5181</a></td>
+  <td><InlineCopy href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" code="0xBBD1F50A212357067318a84179892684e1Ac5181">0xBBD...5181</InlineCopy></td>
   <td></td>
 </tr>
 </tbody>


### PR DESCRIPTION
This could really be one table but it would be too wide for the layout.

Preview: https://docs-etherlink-git-token-addresses-on-wrapped-page-trili-tech.vercel.app/building-on-etherlink/bridging-wrapped-assets

<img width="679" alt="Screenshot 2024-08-06 at 1 48 40 PM" src="https://github.com/user-attachments/assets/6d6e2c0c-d389-47c2-9729-1cd8385e1a14">

<img width="574" alt="Screenshot 2024-08-06 at 1 48 54 PM" src="https://github.com/user-attachments/assets/080fcc62-bc3e-44f1-a2ab-a2b257d35aeb">
