### PR TITLE
Copy-paste issue on WBTC token address

### DIFF
--- a/docs/building-on-etherlink/tokens.mdx
+++ b/docs/building-on-etherlink/tokens.mdx
@@ -62,7 +62,7 @@ Click the address to go to the block explorer page for the token:
 <tr>
   <td>Wrapped BTC</td>
   <td>WBTC</td>
-  <td><InlineCopy code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...sd0F</InlineCopy></td>
+  <td><InlineCopy code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...3d0F</InlineCopy></td>
   <td></td>
 </tr>
 <tr>


### PR DESCRIPTION
The link works by the token abbrev is wrong.