### PR TITLE
Update the EVM node page to use v0.1

### DIFF
--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -7,29 +7,40 @@ The Etherlink EVM nodes are responsible for maintaining a copy of the Etherlink 
 ## Prerequisites
 
 - Make sure you understand the interaction between different nodes as described in [Etherlink architecture](/network/architecture).
-- Run an Etherlink Smart Rollup node as described in [Running an Etherlink Smart Rollup node](/network/smart-rollup-nodes).
+- If you want to verify the blueprints that come from the sequencer, run an Etherlink Smart Rollup node as described in [Running an Etherlink Smart Rollup node](/network/smart-rollup-nodes).
 Public Smart Rollup nodes for Etherlink are not yet available, so you must run your own if you want to participate in the Etherlink network.
 
 The EVM node runs Etherlink's kernel.
 You can get the kernel by importing it from a running Etherlink Smart Rollup node or by providing the installer kernel.
 
-## Running an Etherlink EVM node from an existing Etherlink Smart Rollup node
+## Getting the `octez-evm-node` binary
 
-Follow these steps to run the EVM node from an existing Etherlink Smart Rollup node:
+The easiest way to get the `octez-evm-node` binary is to download the binaries distributed as part of its latest release (currently [`v0.1`](https://gitlab.com/tezos/tezos/-/releases/octez-evm-node-v0.1)).
+More precisely, we provide static binaries for Linux systems (for amd64 and arm64 architectures).
 
-1. Get a built version of the EVM node binary, named `octez-evm-node`.
-Octez does not yet provide a binary build of the EVM node as part of its binary distribution or in the `tezos/tezos` docker image, so you must build it yourself from the latest commit from the Octez source code.
-See [Installing Octez](https://tezos.gitlab.io/introduction/howtoget.html).
-1. Set the `sr_node_observer_rpc` environment variable to the URL to the Smart Rollup node, such as `http://localhost:8932`.
+As an alternative, you can use the minimal Docker image [tezos/tezos-bare:octez-evm-node-v0.1](https://hub.docker.com/layers/tezos/tezos-bare/octez-evm-node-v0.1/images/sha256-e5fdf87f2827dd971e2097faff88c6c6ce53793a2191a903a6a905a647c051f5?context=explore), which contains the correct version of the binary.
+
+## Initializing the data directory
+
+1. If you want your EVM node to check the correctness of the blueprints it receives via a Smart Rollup node, set the `sr_node_observer_rpc` environment variable to the URL of that Etherlink Smart Rollup node, such as `http://localhost:8932`.
 1. Set the `evm_observer_dir` environment variable to the directory where the node should store its local data.
 The default is `$HOME/.octez-evm-node`.
-1. Initialize the node by running this command:
+1. Initialize the node. To trust incoming blueprints, use `--dont-track-rollup-node`:
 
    ```bash
-   octez-evm-node init config --devmode \
+   octez-evm-node init config \
+     --data-dir $evm_observer_dir --dont-track-rollup-node \
+     --preimages-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0 \
+     --evm-node-endpoint https://relay.mainnet.etherlink.com
+   ```
+
+   Alternatively, if you want to rely on a Smart Rollup node to check the correctness of blueprints coming from the sequencer, use `--rollup-node-endpoint`:
+
+   ```bash
+   octez-evm-node init config \
      --data-dir $evm_observer_dir --rollup-node-endpoint $sr_node_observer_rpc \
      --preimages-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0 \
-     --evm-node-endpoint https://node.mainnet.etherlink.com
+     --evm-node-endpoint https://relay.mainnet.etherlink.com
    ```
 
    This configuration uses the preimages that the Tezos Foundation hosts on a file server on a so-called "preimages endpoint".
@@ -37,8 +48,26 @@ The default is `$HOME/.octez-evm-node`.
    If you don't want to use third-party preimages, you can build the kernel yourself and move the contents of the `wasm_2_0_0/` directory to the local data directory; see [Building the Etherlink kernel](/network/building-kernel).
    However, in this case, you must manually update this directory with the preimages of every kernel voted by the community and deployed on Etherlink after that.
 
-1. Set the `sr_observer_data_dir` environment variable to the location of the data directory for the Smart Rollup node.
-The default value is `$HOME/.tezos-smart-rollup-node`.
+## Running the node
+
+You can initialize the node from a snapshot or allow it to compute the Etherlink state from genesis, which can take a long time.
+
+### From an existing Etherlink Smart Rollup node
+
+1. Download [an Etherlink Smart Rollup node snapshot](https://snapshots.eu.tzinit.org/etherlink-ghostnet/), and use the `octez-smart-rollup-node` binary to import it in a temporary directory.
+
+   ```bash
+   wget https://snapshots.eu.tzinit.org/etherlink-mainnet/eth-mainnet.full
+   octez-smart-rollup-node --endpoint https://rpc.tzkt.io/mainnet \
+     snapshot import eth-mainnet.full \
+     --data-dir $sr_observer_data_dir
+   ```
+
+   :::tip
+   If you are running a Smart Rollup node on the same machine, you can skip this step because you can reuse its data directory.
+   :::
+
+1. Set the `sr_observer_data_dir` environment variable to the location of the data directory you got from the previous step.
 
 1. Run this command to import the kernel from the Smart Rollup node:
 
@@ -60,31 +89,9 @@ For example, this command gets the number of the most recent block in hexadecima
 curl -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber"}' http://localhost:8545
 ```
 
-## Running an Etherlink EVM node from the installer kernel
-
-Follow these steps to run the EVM node from the installer kernel:
+### From genesis
 
 1. Get the Etherlink installer kernel (`installer.hex` file), which you can build yourself as described in [Building the Etherlink kernel](/network/building-kernel) or download here: [installer.hex](/files/installer.hex).
-1. Get a built version of the EVM node binary, named `octez-evm-node`.
-Octez does not yet provide a binary build of the EVM node as part of its binary distribution or in the `tezos/tezos` docker image, so you must build it yourself from the latest commit from the Octez source code.
-See [Installing Octez](https://tezos.gitlab.io/introduction/howtoget.html).
-1. Set the `sr_node_observer_rpc` environment variable to the URL to the Smart Rollup node, such as `http://localhost:8932`.
-1. Set the `evm_observer_dir` environment variable to the directory where the node should store its local data.
-The default is `$HOME/.octez-evm-node`.
-1. Initialize the node by running this command:
-
-   ```bash
-   octez-evm-node init config --devmode \
-     --data-dir $evm_observer_dir --rollup-node-endpoint $sr_node_observer_rpc \
-     --preimages-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0 \
-     --evm-node-endpoint https://node.mainnet.etherlink.com
-   ```
-
-   This configuration uses the preimages that the Tezos Foundation hosts on a file server on a so-called "preimages endpoint".
-   It's safe to use these preimages because the node verifies them.
-   If you don't want to use third-party preimages, you can build the kernel yourself and move the contents of the `wasm_2_0_0/` directory to the local data directory; see [Building the Etherlink kernel](/network/building-kernel).
-   However, in this case, you must manually update this directory with the preimages of every kernel voted by the community and deployed on Etherlink after that.
-
 1. Run this command to start the node with the Etherlink installer kernel that you built or downloaded; change the name of the `installer.hex` file in the command accordingly:
 
    ```bash


### PR DESCRIPTION
Notable changes

- We have a release
- We can now run an EVM node without a rollup node
- No longer `--devmode`