### PR TITLE
Instructions for running a Smart Rollup node in operator mode

### DIFF
--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -29,11 +29,13 @@ Running the Smart Rollup node in operator mode is the best way to participate in
 These commitments validate Etherlink's state and ensure that Etherlink is processing blocks and transactions honestly according to its kernel.
 As described in [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) on docs.tezos.com, one honest node is enough to ensure that Etherlink is running correctly, but adding more nodes strengthens its security and allows users to verify for themselves that Etherlink is running as intended.
 
-Running the node in this mode requires an account with at least 10,000 liquid tez and certain other prerequisites:
+Running the node in this mode requires these prerequisites:
 
-- A Tezos layer 1 node running in archive mode; the Smart Rollup node needs the history from around the level that the Smart Rollup was originated to start, but after it has started you can switch to a rolling node
-- An account with at least 10,000 tez staked, referred to as the _operator account_
-- A clean data directory that has not been used for another Smart Rollup node or a node running in a different mode
+- A Tezos layer 1 node running in archive mode.
+The Smart Rollup node needs the full history from the time the snapshot was taken to the current level, which usually means connecting to an archive node, but sometimes it can work with a rolling node that keeps enough history.
+After the node has started, you can switch to a rolling node.
+- An account with at least 10,000 tez staked, referred to as the _operator account_.
+- A clean data directory that has not been used for another Smart Rollup node or a node running in a different mode.
 
 1. Get a built version of the Smart Rollup node binary, named `octez-smart-rollup-node`.
 The best place to get the most recent binary files to use with Etherlink is https://gitlab.com/tezos/tezos/-/releases.

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -41,7 +41,7 @@ Running the node in this mode requires these prerequisites:
 
    You can bootstrap the Smart Rollup node by connecting it to a public layer 1 node, but after the Smart Rollup node bootstraps, you must connect it to a layer 1 node that you control.
    Using a public layer 1 node as the basis for a Smart Rollup node in operator mode exposes the Smart Rollup node to security risks.
-   For example, a malicious layer 1 node can expose the Smart Rollup to an incorrect brach, which can cause the Smart Rollup node to post invalid commitments and lose tez when correct commitments refute them.
+   For example, a malicious layer 1 node can expose the Smart Rollup to an incorrect branch, which can cause the Smart Rollup node to post invalid commitments and lose tez when other operators computing from the correct branch refute them.
 
    :::
 

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -32,9 +32,19 @@ As described in [Smart Rollups](https://docs.tezos.com/architecture/smart-rollup
 Running the node in this mode requires these prerequisites:
 
 - A Tezos layer 1 node running in archive mode.
-The Smart Rollup node needs the full history from the time the snapshot was taken to the current level, which usually means connecting to an archive node, but sometimes it can work with a rolling node that keeps enough history.
-After the node has started, you can switch to a rolling node.
-You can use a public archive node to set up the Smart Rollup node, but for security reasons, you must switch to your own layer 1 node to run the Smart Rollup node in the long term.
+
+   To bootstrap a Smart Rollup node from a snapshot, you need a node that has the full history from the time the snapshot was taken to the current level.
+   Usually this means connecting to an archive node, but if the snapshot is recent, it can work with a rolling node that keeps enough history.
+   After the node has started, you can switch to a rolling node.
+
+   :::warning Using public nodes
+
+   You can bootstrap the Smart Rollup node by connecting it to a public layer 1 node, but after the Smart Rollup node bootstraps, you must connect it to a layer 1 node that you control.
+   Using a public layer 1 node as the basis for a Smart Rollup node in operator mode exposes the Smart Rollup node to problems.
+   For example, a malicious layer 1 node can expose the Smart Rollup to an incorrect brach, which can cause the Smart Rollup node to post invalid commitments and lose tez when correct commitments refute them.
+
+   :::
+
 - An account with at least liquid (unstaked) 10,000 tez, referred to as the _operator account_.
 You can use the same account that you use for your layer 1 baker, but for better security, you can use a different account and delegate its tez to the layer 1 account.
 - A clean data directory that has not been used for another Smart Rollup node or a node running in a different mode.
@@ -113,6 +123,8 @@ For example, this query gets the health of the node:
 
 1. Ensure that the node runs persistently.
 Look up how to run programs persistently in the documentation for your operating system.
+
+1. If you started the node with a public layer 1 node, stop it and restart it with a layer 1 node that you control.
 
 Now that you have a Smart Rollup node configured for Etherlink, you can run an Etherlink EVM node, as described in [Running an Etherlink EVM node](./evm-nodes).
 

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -40,7 +40,7 @@ Running the node in this mode requires these prerequisites:
    :::warning Using public nodes
 
    You can bootstrap the Smart Rollup node by connecting it to a public layer 1 node, but after the Smart Rollup node bootstraps, you must connect it to a layer 1 node that you control.
-   Using a public layer 1 node as the basis for a Smart Rollup node in operator mode exposes the Smart Rollup node to problems.
+   Using a public layer 1 node as the basis for a Smart Rollup node in operator mode exposes the Smart Rollup node to security risks.
    For example, a malicious layer 1 node can expose the Smart Rollup to an incorrect brach, which can cause the Smart Rollup node to post invalid commitments and lose tez when correct commitments refute them.
 
    :::

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -78,7 +78,8 @@ The best place to get the most recent binary files to use with Etherlink is http
       If you don't want to use third-party preimages, you can build the kernel yourself and move the contents of the `wasm_2_0_0/` directory to the local data directory; see [Building the Etherlink kernel](/network/building-kernel).
       However, in this case, you must manually update this directory with the preimages of every kernel voted by the community and deployed on Etherlink after that.
 
-1. (Optional) To speed up the setup process by loading a snapshot, follow these steps:
+1. To speed up the setup process by loading a snapshot, follow these steps.
+If you don't load a snapshot, the node must compute the current state from genesis and that can take a long time.
 
    1. Download the latest snapshot from https://snapshots.eu.tzinit.org/etherlink-mainnet/:
 

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -34,6 +34,7 @@ Running the node in this mode requires these prerequisites:
 - A Tezos layer 1 node running in archive mode.
 The Smart Rollup node needs the full history from the time the snapshot was taken to the current level, which usually means connecting to an archive node, but sometimes it can work with a rolling node that keeps enough history.
 After the node has started, you can switch to a rolling node.
+You can use a public archive node for this purpose, but for better performance, switch to your own node after the Smart Rollup node has started.
 - An account with at least 10,000 tez staked, referred to as the _operator account_.
 - A clean data directory that has not been used for another Smart Rollup node or a node running in a different mode.
 
@@ -94,7 +95,7 @@ If you don't load a snapshot, the node must compute the current state from genes
         --data-dir $SR_DATA_DIR
       ```
 
-1. Start the Smart Rollup node by running this command and using the RPC endpoint of your layer 1 node:
+1. Start the Smart Rollup node by running this command and using the RPC endpoint of the layer 1 node:
 
    ```bash
    octez-smart-rollup-node --endpoint $LAYER_1_NODE run --data-dir $SR_DATA_DIR

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -34,7 +34,7 @@ Running the node in this mode requires these prerequisites:
 - A Tezos layer 1 node running in archive mode.
 The Smart Rollup node needs the full history from the time the snapshot was taken to the current level, which usually means connecting to an archive node, but sometimes it can work with a rolling node that keeps enough history.
 After the node has started, you can switch to a rolling node.
-You can use a public archive node for this purpose, but for better performance, switch to your own node after the Smart Rollup node has started.
+You can use a public archive node to set up the Smart Rollup node, but for security reasons, you must switch to your own layer 1 node to run the Smart Rollup node in the long term.
 - An account with at least liquid (unstaked) 10,000 tez, referred to as the _operator account_.
 You can use the same account that you use for your layer 1 baker, but for better security, you can use a different account and delegate its tez to the layer 1 account.
 - A clean data directory that has not been used for another Smart Rollup node or a node running in a different mode.

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -20,87 +20,16 @@ For more information about Smart Rollup nodes in general, see [Smart Rollups](ht
 
 You can run the Etherlink Smart Rollup in many modes, but these instructions cover only the most common modes:
 
-- [Running the Smart Rollup node in observer mode](#running-the-smart-rollup-node-in-observer-mode)
 - [Running the Smart Rollup node in operator mode](#running-the-smart-rollup-node-in-operator-mode)
+- [Running the Smart Rollup node in observer mode](#running-the-smart-rollup-node-in-observer-mode)
 
 In either case, you can start the Smart Rollup node with a snapshot of the Etherlink state to prevent it from having to compute the state from Etherlink genesis.
 You can also skip the snapshot and run the node from Etherlink genesis, but it can take a long time for the node to catch up.
 These instructions cover both ways of running the Smart Rollup node.
 
-## Running the Smart Rollup node in observer mode
-
-Running the Smart Rollup node in observer mode is the simplest way to run an Etherlink Smart Rollup node, but it does not strengthen the security of the system by posting commitments.
-In observer mode, the node only monitors the state of Etherlink.
-
-1. Get a built version of the Smart Rollup node binary, named `octez-smart-rollup-node`.
-The best place to get the most recent binary files to use with Etherlink is https://gitlab.com/tezos/tezos/-/releases.
-
-1. Initialize the local context of the node, which is where it stores local data:
-
-   1. Set the environment variable `SR_DATA_DIR` to the directory where the node should store its local data.
-   The default value is `$HOME/.tezos-smart-rollup-node`.
-
-   1. Initialize the local context by running this command and using the address of the Etherlink Smart Rollup, which you can get from the [Network information](/get-started/network-information) page:
-
-      ```bash
-      octez-smart-rollup-node init observer config for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
-        with operators --data-dir $SR_DATA_DIR \
-        --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
-      ```
-
-      This command generates a minimal configuration file (`config.json`) in the local data folder:
-
-      ```json
-      { "smart-rollup-address": "sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf",
-        "smart-rollup-node-operator": {}, "fee-parameters": {}, "mode": "observer",
-        "pre-images-endpoint":
-          "https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0" }
-      ```
-
-      This configuration uses the preimages that the Tezos Foundation hosts on a file server on a so-called "preimages endpoint".
-      It's safe to use these preimages because the node verifies them.
-      If you don't want to use third-party preimages, you can build the kernel yourself and move the contents of the `wasm_2_0_0/` directory to the local data directory; see [Building the Etherlink kernel](/network/building-kernel).
-      However, in this case, you must manually update this directory with the preimages of every kernel voted by the community and deployed on Etherlink after that.
-
-1. To speed up the setup process by loading a snapshot, follow these steps:
-
-   1. Download the latest snapshot from https://snapshots.eu.tzinit.org/etherlink-mainnet/:
-
-      ```bash
-      wget https://snapshots.eu.tzinit.org/etherlink-mainnet/eth-mainnet.full
-      ```
-
-   1. Load the snapshot:
-
-      ```bash
-      octez-smart-rollup-node --endpoint https://rpc.tzkt.io/mainnet \
-        snapshot import eth-mainnet.full \
-        --data-dir $SR_DATA_DIR
-      ```
-
-1. Start the Smart Rollup node in observer mode by running this command and using the RPC endpoint of a layer 1 node:
-
-   ```bash
-   octez-smart-rollup-node --endpoint https://rpc.tzkt.io/mainnet run \
-     --data-dir $SR_DATA_DIR
-   ```
-
-   As in this example, you can use a public layer 1 RPC node for initial setup, or you can connect it to a layer 1 node that you are running for a more stable connection.
-
-   If you did not load a snapshot, the process of starting the node from genesis can take a long time because it must process every block.
-
-1. Verify that the Smart Rollup node is running by querying it.
-For example, this query gets the health of the node:
-
-   ```bash
-   curl -s http://localhost:8932/health
-   ```
-
-Now that you have a Smart Rollup node configured for Etherlink, you can run an Etherlink EVM node, as described in [Running an Etherlink EVM node](/network/evm-nodes).
-
 ## Running the Smart Rollup node in operator mode
 
-Running the Smart Rollup node in operator mode is the best way to secure Etherlink because in this mode the node posts commitments about Etherlink's state to layer 1.
+Running the Smart Rollup node in operator mode is the best way to participate in Etherlink because in this mode the node posts commitments about Etherlink's state to layer 1.
 However, running the node in this mode requires an account with at least 10,000 staked tez and certain other prerequisites.
 
 To run an Etherlink Smart Rollup node in operator mode, you need:
@@ -185,5 +114,76 @@ For example, this query gets the health of the node:
 
 1. Ensure that the node runs persistently.
 Look up how to run programs persistently in the documentation for your operating system.
+
+Now that you have a Smart Rollup node configured for Etherlink, you can run an Etherlink EVM node, as described in [Running an Etherlink EVM node](./evm-nodes).
+
+## Running the Smart Rollup node in observer mode
+
+Running the Smart Rollup node in observer mode is the simplest way to run an Etherlink Smart Rollup node, but it does not strengthen the security of the system by posting commitments.
+In observer mode, the node only monitors the state of Etherlink.
+
+1. Get a built version of the Smart Rollup node binary, named `octez-smart-rollup-node`.
+The best place to get the most recent binary files to use with Etherlink is https://gitlab.com/tezos/tezos/-/releases.
+
+1. Initialize the local context of the node, which is where it stores local data:
+
+   1. Set the environment variable `SR_DATA_DIR` to the directory where the node should store its local data.
+   The default value is `$HOME/.tezos-smart-rollup-node`.
+
+   1. Initialize the local context by running this command and using the address of the Etherlink Smart Rollup, which you can get from the [Network information](/get-started/network-information) page:
+
+      ```bash
+      octez-smart-rollup-node init observer config for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
+        with operators --data-dir $SR_DATA_DIR \
+        --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
+      ```
+
+      This command generates a minimal configuration file (`config.json`) in the local data folder:
+
+      ```json
+      { "smart-rollup-address": "sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf",
+        "smart-rollup-node-operator": {}, "fee-parameters": {}, "mode": "observer",
+        "pre-images-endpoint":
+          "https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0" }
+      ```
+
+      This configuration uses the preimages that the Tezos Foundation hosts on a file server on a so-called "preimages endpoint".
+      It's safe to use these preimages because the node verifies them.
+      If you don't want to use third-party preimages, you can build the kernel yourself and move the contents of the `wasm_2_0_0/` directory to the local data directory; see [Building the Etherlink kernel](/network/building-kernel).
+      However, in this case, you must manually update this directory with the preimages of every kernel voted by the community and deployed on Etherlink after that.
+
+1. To speed up the setup process by loading a snapshot, follow these steps:
+
+   1. Download the latest snapshot from https://snapshots.eu.tzinit.org/etherlink-mainnet/:
+
+      ```bash
+      wget https://snapshots.eu.tzinit.org/etherlink-mainnet/eth-mainnet.full
+      ```
+
+   1. Load the snapshot:
+
+      ```bash
+      octez-smart-rollup-node --endpoint https://rpc.tzkt.io/mainnet \
+        snapshot import eth-mainnet.full \
+        --data-dir $SR_DATA_DIR
+      ```
+
+1. Start the Smart Rollup node in observer mode by running this command and using the RPC endpoint of a layer 1 node:
+
+   ```bash
+   octez-smart-rollup-node --endpoint https://rpc.tzkt.io/mainnet run \
+     --data-dir $SR_DATA_DIR
+   ```
+
+   As in this example, you can use a public layer 1 RPC node for initial setup, or you can connect it to a layer 1 node that you are running for a more stable connection.
+
+   If you did not load a snapshot, the process of starting the node from genesis can take a long time because it must process every block.
+
+1. Verify that the Smart Rollup node is running by querying it.
+For example, this query gets the health of the node:
+
+   ```bash
+   curl -s http://localhost:8932/health
+   ```
 
 Now that you have a Smart Rollup node configured for Etherlink, you can run an Etherlink EVM node, as described in [Running an Etherlink EVM node](./evm-nodes).

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -35,7 +35,8 @@ Running the node in this mode requires these prerequisites:
 The Smart Rollup node needs the full history from the time the snapshot was taken to the current level, which usually means connecting to an archive node, but sometimes it can work with a rolling node that keeps enough history.
 After the node has started, you can switch to a rolling node.
 You can use a public archive node for this purpose, but for better performance, switch to your own node after the Smart Rollup node has started.
-- An account with at least 10,000 tez staked, referred to as the _operator account_.
+- An account with at least liquid (unstaked) 10,000 tez, referred to as the _operator account_.
+You can use the same account that you use for your layer 1 baker, but for better security, you can use a different account and delegate its tez to the layer 1 account.
 - A clean data directory that has not been used for another Smart Rollup node or a node running in a different mode.
 
 1. Get a built version of the Smart Rollup node binary, named `octez-smart-rollup-node`.

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -30,7 +30,7 @@ These instructions cover both ways of running the Smart Rollup node.
 ## Running the Smart Rollup node in operator mode
 
 Running the Smart Rollup node in operator mode is the best way to participate in Etherlink because in this mode the node posts commitments about Etherlink's state to layer 1.
-However, running the node in this mode requires an account with at least 10,000 staked tez and certain other prerequisites.
+However, running the node in this mode requires an account with at least 10,000 liquid tez and certain other prerequisites.
 
 To run an Etherlink Smart Rollup node in operator mode, you need:
 

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -36,7 +36,6 @@ To run an Etherlink Smart Rollup node in operator mode, you need:
 
 - A Tezos layer 1 node running in archive mode or full mode with expanded node history, such as with the argument `--history-mode full:50`
 - An account with at least 10,000 tez staked, referred to as the _operator account_
-- A separate account to sign batching operations, referred to as the _batcher account_; this account is necessary only if you also run an Etherlink EVM node
 - A clean data directory that has not been used for another Smart Rollup node or a node running in a different mode
 
 1. Get a built version of the Smart Rollup node binary, named `octez-smart-rollup-node`.
@@ -47,14 +46,13 @@ The best place to get the most recent binary files to use with Etherlink is http
    1. Set the environment variable `SR_DATA_DIR` to the directory where the node should store its local data.
    The default value is `$HOME/.tezos-smart-rollup-node`.
 
-   1. Initialize the local context by running this command and using the address of the Etherlink Smart Rollup, which you can get from the [Network information](/get-started/network-information) page, and the addresses or Octez client aliases for the operator account and the batcher account:
+   1. Initialize the local context by running this command and using the address of the Etherlink Smart Rollup, which you can get from the [Network information](/get-started/network-information) page, and the address or Octez client alias for the operator account:
 
       ```bash
       octez-smart-rollup-node init operator config for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
         with operators \
         operating:$OPERATOR_ACCOUNT \
         cementing:$OPERATOR_ACCOUNT \
-        batching:$BATCHER_ACCOUNT \
         executing_outbox:$OPERATOR_ACCOUNT \
         --history-mode archive \
         --rpc-addr 0.0.0.0 \
@@ -68,7 +66,6 @@ The best place to get the most recent binary files to use with Etherlink is http
       { "smart-rollup-address": "sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf",
         "smart-rollup-node-operator":
           { "operating": "tz1QCVQinE8iVj1H2fckqx6oiM85CNJSK9Sx",
-            "batching": [ "tz1hQKqRPHmxET8du3fNACGyCG8kZRsXm2zD" ],
             "cementing": "tz1QCVQinE8iVj1H2fckqx6oiM85CNJSK9Sx",
             "executing_outbox": "tz1QCVQinE8iVj1H2fckqx6oiM85CNJSK9Sx" },
         "fee-parameters": {}, "mode": "operator",

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -31,7 +31,7 @@ As described in [Smart Rollups](https://docs.tezos.com/architecture/smart-rollup
 
 Running the node in this mode requires an account with at least 10,000 liquid tez and certain other prerequisites:
 
-- A Tezos layer 1 node running in archive mode or full mode with expanded node history, such as with the argument `--history-mode full:50`
+- A Tezos layer 1 node running in archive mode; the Smart Rollup node needs the history from around the level that the Smart Rollup was originated to start, but after it has started you can switch to a rolling node
 - An account with at least 10,000 tez staked, referred to as the _operator account_
 - A clean data directory that has not been used for another Smart Rollup node or a node running in a different mode
 

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -18,9 +18,11 @@ Make sure that you understand the interaction between different nodes as describ
 
 For more information about Smart Rollup nodes in general, see [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) on docs.tezos.com and [Smart Rollup Node](https://tezos.gitlab.io/shell/smart_rollup_node.html) in the Octez documentation.
 
-## Running the Smart Rollup node from a snapshot
+## Running the Smart Rollup node
 
 You can start the Smart Rollup node with a snapshot of the Etherlink state to prevent it from having to compute the state from Etherlink genesis.
+You can also skip the snapshot and run the node from Etherlink genesis, but it can take a long time for the node to catch up.
+These instructions cover both ways of running the Smart Rollup node.
 
 For simplicity, these steps show how to run the Smart Rollup node in observer mode:
 
@@ -53,19 +55,21 @@ The best place to get the most recent binary files to use with Etherlink is http
       If you don't want to use third-party preimages, you can build the kernel yourself and move the contents of the `wasm_2_0_0/` directory to the local data directory; see [Building the Etherlink kernel](/network/building-kernel).
       However, in this case, you must manually update this directory with the preimages of every kernel voted by the community and deployed on Etherlink after that.
 
-1. Download the latest snapshot from https://snapshots.eu.tzinit.org/etherlink-mainnet/:
+1. To speed up the setup process by loading a snapshot, follow these steps:
 
-   ```bash
-   wget https://snapshots.eu.tzinit.org/etherlink-mainnet/eth-mainnet.full
-   ```
+   1. Download the latest snapshot from https://snapshots.eu.tzinit.org/etherlink-mainnet/:
 
-1. Load the snapshot:
+      ```bash
+      wget https://snapshots.eu.tzinit.org/etherlink-mainnet/eth-mainnet.full
+      ```
 
-   ```bash
-   octez-smart-rollup-node --endpoint https://rpc.tzkt.io/mainnet \
-     snapshot import eth-mainnet.full \
-     --data-dir $sr_observer_data_dir
-   ```
+   1. Load the snapshot:
+
+      ```bash
+      octez-smart-rollup-node --endpoint https://rpc.tzkt.io/mainnet \
+        snapshot import eth-mainnet.full \
+        --data-dir $sr_observer_data_dir
+      ```
 
 1. Start the Smart Rollup node in observer mode by running this command and using the RPC endpoint of a layer 1 node:
 
@@ -78,61 +82,7 @@ The best place to get the most recent binary files to use with Etherlink is http
    A rolling node is sufficient if you are using a recent snapshot; if the snapshot is old, the Smart Rollup node needs a connection to an archive node.
    After that you can connect it to a rolling node.
 
-1. Verify that the Smart Rollup node is running by querying it.
-For example, this query gets the health of the node:
-
-   ```bash
-   curl -s http://localhost:8932/health
-   ```
-
-Now that you have a Smart Rollup node configured for Etherlink, you can run an Etherlink EVM node, as described in [Running an Etherlink EVM node](/network/evm-nodes).
-
-## Running the Smart Rollup node from Etherlink genesis
-
-Running the Smart Rollup node from Etherlink genesis takes time but does not rely on snapshots created by third parties.
-
-For simplicity, these steps show how to run the Smart Rollup node in observer mode:
-
-1. Get a built version of the Smart Rollup node binary, named `octez-smart-rollup-node`.
-The best place to get the most recent binary files to use with Etherlink is https://gitlab.com/tezos/tezos/-/releases.
-
-1. Initialize the local context of the node, which is where it stores local data:
-
-   1. Set the environment variable `sr_observer_data_dir` to the directory where the node should store its local data.
-   The default value is `$HOME/.tezos-smart-rollup-node`.
-   1. Initialize the local context by running this command:
-
-      ```bash
-      octez-smart-rollup-node init observer config for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
-        with operators --data-dir $sr_observer_data_dir \
-        --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
-      ```
-
-      This command generates a minimal configuration file (`config.json`) in the local data folder:
-
-      ```json
-      { "smart-rollup-address": "sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf",
-        "smart-rollup-node-operator": {}, "fee-parameters": {}, "mode": "observer",
-        "pre-images-endpoint":
-          "https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0" }
-      ```
-
-      This configuration uses the preimages that the Tezos Foundation hosts on a file server on a so-called "preimages endpoint".
-      It's safe to use these preimages because the node verifies them.
-      If you don't want to use third-party preimages, you can build the kernel yourself and move the contents of the `wasm_2_0_0/` directory to the local data directory; see [Building the Etherlink kernel](/network/building-kernel).
-      However, in this case, you must manually update this directory with the preimages of every kernel voted by the community and deployed on Etherlink after that.
-
-1. Start the Smart Rollup node in observer mode by running this command and using the RPC endpoint of a layer 1 node that is running in archive mode:
-
-   ```bash
-   octez-smart-rollup-node --endpoint https://rpc.tzkt.io/mainnet run \
-     --data-dir $sr_observer_data_dir
-   ```
-
-   The layer 1 node must be running in archive mode to provide your Smart Rollup node  information about the Etherlink state since its genesis.
-   As in this example, you can use a public layer 1 RPC node for initial setup, or you can connect it to a layer 1 node that you are running for a more stable connection.
-
-   The process of starting the node from genesis can take a long time because it must process every block.
+   If you did not load a snapshot, the process of starting the node from genesis can take a long time because it must process every block.
 
 1. Verify that the Smart Rollup node is running by querying it.
 For example, this query gets the health of the node:

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -23,16 +23,13 @@ You can run the Etherlink Smart Rollup in many modes, but these instructions cov
 - [Running the Smart Rollup node in operator mode](#running-the-smart-rollup-node-in-operator-mode)
 - [Running the Smart Rollup node in observer mode](#running-the-smart-rollup-node-in-observer-mode)
 
-In either case, you can start the Smart Rollup node with a snapshot of the Etherlink state to prevent it from having to compute the state from Etherlink genesis.
-You can also skip the snapshot and run the node from Etherlink genesis, but it can take a long time for the node to catch up.
-These instructions cover both ways of running the Smart Rollup node.
-
 ## Running the Smart Rollup node in operator mode
 
 Running the Smart Rollup node in operator mode is the best way to participate in Etherlink because in this mode the node posts commitments about Etherlink's state to layer 1.
-However, running the node in this mode requires an account with at least 10,000 liquid tez and certain other prerequisites.
+These commitments validate Etherlink's state and ensure that Etherlink is processing blocks and transactions honestly according to its kernel.
+As described in [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) on docs.tezos.com, one honest node is enough to ensure that Etherlink is running correctly, but adding more nodes strengthens its security and allows users to verify for themselves that Etherlink is running as intended.
 
-To run an Etherlink Smart Rollup node in operator mode, you need:
+Running the node in this mode requires an account with at least 10,000 liquid tez and certain other prerequisites:
 
 - A Tezos layer 1 node running in archive mode or full mode with expanded node history, such as with the argument `--history-mode full:50`
 - An account with at least 10,000 tez staked, referred to as the _operator account_


### PR DESCRIPTION
Preview: https://docs-etherlink-git-operator-trili-tech.vercel.app/network/smart-rollup-nodes#running-the-smart-rollup-node-in-operator-mode

References: 
- https://chrispinnock.com/2024/03/01/how-to-setup-an-etherlink-rollup-node.html
- https://tezos.gitlab.io/shell/smart_rollup_node.html

Questions:
- [x] Why use a separate key for batching?
- [x] Can my stake overlap? That is, if I have 6k tez staked for my layer 1 node, do I need to stake only an additional 4k to make 10k for the SR operator, or do I need to stake the full 10k in addition?
- [x] Can I use the same key for the SR node operator as I do for my layer 1 node operator?
- [x] Does it make sense to keep the instructions for observer mode or should we provide only operator mode? Maybe operator mode first and then observer mode as a shortcut?
- [x] Is it enough to say "run persistently" or should I give systemctl instructions like in Chris's blog post?
- [x] Is it accurate to say that the SR node needs a connection to a layer 1 node either in archive mode or in full mode with `--history-mode full:50` (as I'm seeing form error messages)?

Next draft of  this should show how to start with an observer node and upgrade to operator. Something like (1) bootstrap in observer mode, (2) restart against a owned L1 node in observer mode, check everything works, then (3) restart in operator mode