### PR TITLE
Link to our topic on The Graph

### DIFF
--- a/docs/tools/data-indexers.md
+++ b/docs/tools/data-indexers.md
@@ -6,7 +6,7 @@ title: Data indexers
 
 [The Graph](https://thegraph.com/) is an indexing protocol for organizing blockchain data and making it easily accessible with GraphQL. Etherlink dApps can use GraphQL to query open APIs called subgraphs, to retrieve data that is indexed on the network.
 
-Learn how to create and deploy your own subgraph in this [guide](https://thegraph.com/docs/en/quick-start/), and find more about querying existing subgraphs [here](https://thegraph.com/docs/en/querying/querying-the-graph/).
+For information on indexing contracts with The Graph, see [Indexing Etherlink contracts with TheGraph](/building-on-etherlink/indexing-graph).
 
 ## Subsquid
 


### PR DESCRIPTION
We have a topic on The Graph but it is not linked to from the tools page.