### PR TITLE
Correct order of operations in this note

### DIFF
--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -131,7 +131,7 @@ Converting the observer node to maintenance mode requires these prerequisites:
    Using a public layer 1 node as the basis for a Smart Rollup node in maintenance or operator mode exposes the Smart Rollup node to security risks.
    For example, a malicious layer 1 node can expose the Smart Rollup node to an incorrect branch, which can cause the Smart Rollup node to post invalid commitments and lose tez when other node operators computing from the correct branch refute them.
 
-   As these steps describe, it is safe to bootstrap a node in observer mode by connecting it to a public node, switch to maintenance or operator mode, and then promptly connect it to a layer 1 node that you control.
+   As these steps describe, it is safe to bootstrap a node in observer mode by connecting it to a public node, connect it to a layer 1 node that you control, and then switch to maintenance or operator mode.
 
    :::
 


### PR DESCRIPTION
We changed the steps to this:
1. Bootstrap node in observer mode with a public layer 1 node
2. Switch to your own layer 1 node
3. Change to maintenance or operator mode

But the note about security uses the old ordering. This PR fixes the ordering.