### PR TITLE
Info about using bailout mode to recover bond and unstake

### DIFF
--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -225,7 +225,7 @@ Then you can recover the node's bonded tez and stop the node.
 
 :::warning
 
-If you stop the node before waiting for its last commitment to be cemented, the bonded tez is at risk if other Smart Rollup nodes challenge that commitment and your node is not online to defend it in the Smart Rollup refutation game.
+If you stop the node before waiting for its last commitment to be cemented, the bonded tez is at risk if other challenge that commitment and your node is not online to defend it in the Smart Rollup refutation game.
 For more information, see [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) on docs.tezos.com.
 
 :::

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -197,7 +197,8 @@ This example uses `$OPERATOR_ACCOUNT` for the account with 10,000 liquid tez and
      --history-mode archive \
      --rpc-addr 0.0.0.0 \
      --data-dir $SR_DATA_DIR \
-     --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
+     --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0 \
+     --force
    ```
 
    This command generates updates the configuration file to contain the addresses of the accounts that post operations to layer 1, including the node's commitments.
@@ -247,7 +248,8 @@ A node running in `bailout` mode defends its existing commitments but does not m
         executing_outbox:$SECONDARY_ACCOUNT \
         --rpc-addr 0.0.0.0 \
         --data-dir $SR_DATA_DIR \
-        --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
+        --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0 \
+        --force
       ```
 
    1. Restart the node:

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -165,6 +165,7 @@ Converting the observer node to maintenance mode requires these prerequisites:
 
 - An account with at least 10,000 liquid, available tez, referred to as the _operator account_.
 You can use the same account that you use for a layer 1 baker, but for better security, you can use a different account and delegate its tez to the layer 1 account.
+Without 10,000 liquid tez, the Smart Rollup node will not start in operator or maintenance mode.
 
 - An account with a small amount of liquid tez for cementing and outbox operations.
 

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -241,10 +241,7 @@ A node running in `bailout` mode defends its existing commitments but does not m
 
       ```bash
       octez-smart-rollup-node init bailout config for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
-        with operators \
-        operating:$OPERATOR_ACCOUNT \
-        cementing:$SECONDARY_ACCOUNT \
-        executing_outbox:$SECONDARY_ACCOUNT \
+        with operators $OPERATOR_ACCOUNT cementing:$SECONDARY_ACCOUNT \
         --rpc-addr 0.0.0.0 \
         --data-dir $SR_DATA_DIR \
         --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0 \

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -258,7 +258,7 @@ A node running in `bailout` mode defends its existing commitments but does not m
         --data-dir $SR_DATA_DIR
       ```
 
-1. Wait two weeks for the node's last commitment to be cemented.
+1. Keep the node running for two weeks for the node's last commitment to be cemented.
 
 1. Recover the node's bonded tez by running this command:
 

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -225,7 +225,7 @@ Then you can recover the node's bonded tez and stop the node.
 
 :::warning
 
-If you stop the node before waiting for its last commitment to be cemented, the bonded tez is at risk if other challenge that commitment and your node is not online to defend it in the Smart Rollup refutation game.
+If you stop the node before waiting for its last commitment to be cemented, the bonded tez is at risk if other nodes challenge that commitment and your node is not online to defend it in the Smart Rollup refutation game.
 For more information, see [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) on docs.tezos.com.
 
 :::

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -217,3 +217,6 @@ For example, this query gets the health of the node:
    ```
 
 Now that you have a Smart Rollup node configured for Etherlink, you can run an Etherlink EVM node, as described in [Running an Etherlink EVM node](/network/evm-nodes).
+
+When you want to stop running the Smart Rollup node, you can stop the `octez-smart-rollup-node` process and unstake the tez for the account with the `octez-client unstake` and `octez-client finalize unstake` commands.
+For more information, see [Staking mechanism](https://tezos.gitlab.io/alpha/staking.html) in the Octez documentation.

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -194,7 +194,6 @@ This example uses `$OPERATOR_ACCOUNT` for the account with 10,000 liquid tez and
      operating:$OPERATOR_ACCOUNT \
      cementing:$SECONDARY_ACCOUNT \
      executing_outbox:$SECONDARY_ACCOUNT \
-     --history-mode archive \
      --rpc-addr 0.0.0.0 \
      --data-dir $SR_DATA_DIR \
      --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0 \

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -232,7 +232,9 @@ A node running in `bailout` mode defends its existing commitments but does not m
    ```bash
    octez-smart-rollup-node run bailout for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
      with operators \
-     cementing:$SECONDARY_ACCOUNT \
+     operating:$OPERATOR_ACCOUNT \
+     cementing:$OPERATOR_ACCOUNT \
+     recovering:$OPERATOR_ACCOUNT \
      --endpoint $MY_LAYER_1_NODE \
      --rpc-addr 0.0.0.0 \
      --data-dir $SR_DATA_DIR \

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -240,7 +240,14 @@ A node running in `bailout` mode defends its existing commitments but does not m
    1. Re-initialize the node for `bailout` mode by running this command:
 
       ```bash
-      octez-smart-rollup-node init ... TODO write and test command
+      octez-smart-rollup-node init bailout config for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
+        with operators \
+        operating:$OPERATOR_ACCOUNT \
+        cementing:$SECONDARY_ACCOUNT \
+        executing_outbox:$SECONDARY_ACCOUNT \
+        --rpc-addr 0.0.0.0 \
+        --data-dir $SR_DATA_DIR \
+        --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
       ```
 
    1. Restart the node:

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -163,7 +163,7 @@ Converting the observer node to maintenance mode requires these prerequisites:
 
    :::
 
-- An account with at least 10,000 liquid (unstaked) tez, referred to as the _operator account_.
+- An account with at least 10,000 liquid, available tez, referred to as the _operator account_.
 You can use the same account that you use for a layer 1 baker, but for better security, you can use a different account and delegate its tez to the layer 1 account.
 
 - An account with a small amount of liquid tez for cementing and outbox operations.

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -224,35 +224,35 @@ For more information, see [Smart Rollups](https://docs.tezos.com/architecture/sm
 
 Follow these steps to stop an Etherlink Smart Rollup node:
 
-1. Switch the node to `bailout` mode.
+1. Stop the node temporarily.
+
+1. Restart the node in `bailout` mode.
 A node running in `bailout` mode defends its existing commitments but does not make new commitments.
 
-   1. Stop the node.
-
-   1. Restart the node in bailout mode:
-
-      ```bash
-      octez-smart-rollup-node run bailout for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
-        with operators \
-        cementing:$SECONDARY_ACCOUNT \
-        --endpoint $MY_LAYER_1_NODE \
-        --rpc-addr 0.0.0.0 \
-        --data-dir $SR_DATA_DIR \
-        --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
-      ```
+   ```bash
+   octez-smart-rollup-node run bailout for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
+     with operators \
+     cementing:$SECONDARY_ACCOUNT \
+     --endpoint $MY_LAYER_1_NODE \
+     --rpc-addr 0.0.0.0 \
+     --data-dir $SR_DATA_DIR \
+     --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
+   ```
 
 1. Keep the node running for two weeks for the node's last commitment to be cemented.
 
-1. Recover the node's bonded tez by running this command:
+1. When the last commitment is cemented, the node automatically recovers the bonded tez and shuts down.
 
-   ```bash
-   octez-client recover bond of $BONDED_ACCOUNT for smart rollup $SMART_ROLLUP_ADDRESS from $MY_ACCOUNT
-   ```
+Now the node has stopped and the bonded tez is liquid.
 
-   This command uses these arguments:
+If you want to recover the bond manually, use this command:
 
-      - `BONDED_ACCOUNT`: The account that you used to run the Smart Rollup in operator mode
-      - `SMART_ROLLUP_ADDRESS`: The address of the Etherlink Smart Rollup
-      - `MY_ACCOUNT`: The account to use to send this `recover bond` operation
+```bash
+octez-client recover bond of $BONDED_ACCOUNT for smart rollup $SMART_ROLLUP_ADDRESS from $MY_ACCOUNT
+```
 
-1. Stop the node.
+This command uses these arguments:
+
+- `BONDED_ACCOUNT`: The account that you used to run the Smart Rollup in operator mode
+- `SMART_ROLLUP_ADDRESS`: The address of the Etherlink Smart Rollup
+- `MY_ACCOUNT`: The account to use to send this `recover bond` operation

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -212,7 +212,7 @@ Now that you have a Smart Rollup node configured for Etherlink, you can run an E
 
 ## Stopping the Smart Rollup node
 
-When you want to stop running the Smart Rollup node, you must wait for the last commitment that your node made to be cemented.
+When you want to stop running the Smart Rollup node, you must wait for the last commitment that your node made to be cemented if you had any.
 Then you can recover the node's bonded tez and stop the node.
 
 :::warning

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -185,28 +185,19 @@ Follow these steps to convert a Smart Rollup node from observer mode to maintena
 
 1. Stop the node.
 
-1. Re-initialize the node for maintenance mode by running the `init maintenance config` command and passing the addresses or Octez aliases of the accounts.
+1. Run the node in maintenance mode, passing the addresses or Octez aliases of the accounts and the layer 1 node that you control.
 This example uses `$OPERATOR_ACCOUNT` for the account with 10,000 liquid tez and `$SECONDARY_ACCOUNT` for the other account:
 
    ```bash
-   octez-smart-rollup-node init maintenance config for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
+   octez-smart-rollup-node run maintenance for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
      with operators \
      operating:$OPERATOR_ACCOUNT \
      cementing:$SECONDARY_ACCOUNT \
      executing_outbox:$SECONDARY_ACCOUNT \
+     --endpoint $MY_LAYER_1_NODE \
      --rpc-addr 0.0.0.0 \
      --data-dir $SR_DATA_DIR \
-     --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0 \
-     --force
-   ```
-
-   This command generates updates the configuration file to contain the addresses of the accounts that post operations to layer 1, including the node's commitments.
-
-1. Restart the node, again with the layer 1 node that you control:
-
-   ```bash
-   octez-smart-rollup-node --endpoint $MY_LAYER_1_NODE run \
-     --data-dir $SR_DATA_DIR
+     --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
    ```
 
 1. Verify that the Smart Rollup node is running by querying it.
@@ -237,22 +228,16 @@ A node running in `bailout` mode defends its existing commitments but does not m
 
    1. Stop the node.
 
-   1. Re-initialize the node for `bailout` mode by running this command:
+   1. Restart the node in bailout mode:
 
       ```bash
-      octez-smart-rollup-node init bailout config for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
-        with operators $OPERATOR_ACCOUNT cementing:$SECONDARY_ACCOUNT \
+      octez-smart-rollup-node run bailout for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
+        with operators \
+        cementing:$SECONDARY_ACCOUNT \
+        --endpoint $MY_LAYER_1_NODE \
         --rpc-addr 0.0.0.0 \
         --data-dir $SR_DATA_DIR \
-        --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0 \
-        --force
-      ```
-
-   1. Restart the node:
-
-      ```bash
-      octez-smart-rollup-node --endpoint $MY_LAYER_1_NODE run \
-        --data-dir $SR_DATA_DIR
+        --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
       ```
 
 1. Keep the node running for two weeks for the node's last commitment to be cemented.

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -187,12 +187,14 @@ Follow these steps to convert a Smart Rollup node from observer mode to maintena
 1. Stop the node.
 
 1. Run the node in maintenance mode, passing the addresses or Octez aliases of the accounts and the layer 1 node that you control.
-This example uses `$OPERATOR_ACCOUNT` for the account with 10,000 liquid tez and `$SECONDARY_ACCOUNT` for the other account:
+
+   The first address after `with operators` is the default address that the node uses for operations.
+   You can use different accounts for specific operations by adding the operation and the address to the command.
+   This example uses `$OPERATOR_ACCOUNT` for the account with 10,000 liquid tez and `$SECONDARY_ACCOUNT` for cementing operations and executing outbox operations:
 
    ```bash
    octez-smart-rollup-node run maintenance for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
-     with operators \
-     operating:$OPERATOR_ACCOUNT \
+     with operators $OPERATOR_ACCOUNT \
      cementing:$SECONDARY_ACCOUNT \
      executing_outbox:$SECONDARY_ACCOUNT \
      --endpoint $MY_LAYER_1_NODE \
@@ -231,10 +233,7 @@ A node running in `bailout` mode defends its existing commitments but does not m
 
    ```bash
    octez-smart-rollup-node run bailout for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
-     with operators \
-     operating:$OPERATOR_ACCOUNT \
-     cementing:$OPERATOR_ACCOUNT \
-     recovering:$OPERATOR_ACCOUNT \
+     with operators $OPERATOR_ACCOUNT \
      --endpoint $MY_LAYER_1_NODE \
      --rpc-addr 0.0.0.0 \
      --data-dir $SR_DATA_DIR \

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -218,5 +218,50 @@ For example, this query gets the health of the node:
 
 Now that you have a Smart Rollup node configured for Etherlink, you can run an Etherlink EVM node, as described in [Running an Etherlink EVM node](/network/evm-nodes).
 
-When you want to stop running the Smart Rollup node, you can stop the `octez-smart-rollup-node` process and unstake the tez for the account with the `octez-client unstake` and `octez-client finalize unstake` commands.
-For more information, see [Staking mechanism](https://tezos.gitlab.io/alpha/staking.html) in the Octez documentation.
+## Stopping the Smart Rollup node
+
+When you want to stop running the Smart Rollup node, you must wait for the last commitment that your node made to be cemented.
+Then you can recover the node's bonded tez and stop the node.
+
+:::warning
+
+If you stop the node before waiting for its last commitment to be cemented, the bonded tez is at risk if other Smart Rollup nodes challenge that commitment and your node is not online to defend it in the Smart Rollup refutation game.
+For more information, see [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) on docs.tezos.com.
+
+:::
+
+Follow these steps to stop an Etherlink Smart Rollup node:
+
+1. Switch the node to `bailout` mode.
+A node running in `bailout` mode defends its existing commitments but does not make new commitments.
+
+   1. Stop the node.
+
+   1. Re-initialize the node for `bailout` mode by running this command:
+
+      ```bash
+      octez-smart-rollup-node init ... TODO write and test command
+      ```
+
+   1. Restart the node:
+
+      ```bash
+      octez-smart-rollup-node --endpoint $MY_LAYER_1_NODE run \
+        --data-dir $SR_DATA_DIR
+      ```
+
+1. Wait two weeks for the node's last commitment to be cemented.
+
+1. Recover the node's bonded tez by running this command:
+
+   ```bash
+   octez-client recover bond of $BONDED_ACCOUNT for smart rollup $SMART_ROLLUP_ADDRESS from $MY_ACCOUNT
+   ```
+
+   This command uses these arguments:
+
+      - `BONDED_ACCOUNT`: The account that you used to run the Smart Rollup in operator mode
+      - `SMART_ROLLUP_ADDRESS`: The address of the Etherlink Smart Rollup
+      - `MY_ACCOUNT`: The account to use to send this `recover bond` operation
+
+1. Stop the node.


### PR DESCRIPTION
Per node operator feedback, we should mention how to unstake when you're done running the Smart Rollup node.