### PR TITLE
Correct Mainnet chain ID on Hardhat pagae

### DIFF
--- a/docs/building-on-etherlink/development-toolkits.md
+++ b/docs/building-on-etherlink/development-toolkits.md
@@ -34,7 +34,7 @@ module.exports = {
     customChains: [
       {
         network: "etherlinkMainnet",
-        chainId: 128123,
+        chainId: 42793,
         urls: {
           apiURL: "https://explorer.etherlink.com/api",
           browserURL: "https://explorer.etherlink.com",


### PR DESCRIPTION
The Hardhat page has the same chain ID for Testnet and Mainnet.

<img width="596" alt="Screenshot 2024-10-14 at 8 25 40 AM" src="https://github.com/user-attachments/assets/132c1b77-07ac-49cb-8a32-5fe9a16a6d51">
