### PR TITLE
Mention modes for Smart Rollup nodes

### DIFF
--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -107,6 +107,8 @@ curl -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","metho
    octez-evm-node run observer --data-dir $evm_observer_dir
    ```
 
+   The EVM node runs in archive mode.
+
 By default, the EVM node exposes its JSON RPC API endpoint to `localhost:8545`.
 You can test that everything works as expected by running RPC requests manually or by setting your wallet to use your local node.
 For example, this command gets the number of the most recent block in hexadecimal:

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -114,6 +114,9 @@ The best place to get the most recent binary files to use with Etherlink is http
 
    If you loaded a snapshot, the node must process every block that has been created since the snapshot was taken, which takes time depending on the age of the snapshot.
 
+   By default, the node runs in archive mode.
+   To run in full mode, which stores only the minimal data since the genesis required to reconstruct the ledger state, pass the argument `--history-mode full`.
+
 1. Verify that the Smart Rollup node is running by querying it.
 For example, this query gets the health of the node:
 


### PR DESCRIPTION
The SR node runs in archive mode by default; add that info and how to make it run in full mode.