### PR TITLE
Update URLs and UI for new bridge

### DIFF
--- a/docs/bridging/bridging-evm.mdx
+++ b/docs/bridging/bridging-evm.mdx
@@ -5,7 +5,7 @@ title: Bridging tokens between Etherlink and other EVM networks
 import InlineCopy from '@site/src/components/InlineCopy';
 import Video from '@site/src/components/Video';
 
-[The Etherlink wrapped asset bridge](https://www.etherlinkbridge.com/) is a web application that allows you to transfer wrapped tokens between Etherlink and several other EVM-compatible blockchain networks.
+[The Etherlink EVM bridge](https://www.etherlinkbridge.com/bridge) is a web application that allows you to transfer wrapped tokens between Etherlink and several other EVM-compatible blockchain networks.
 The bridge uses the decentralized smart contracts of [LayerZero](https://layerzero.network/) that are deployed on each of those networks without the intervention of a third party.
 
 The EVM bridge supports connections from Etherlink to these networks:
@@ -29,15 +29,15 @@ It allows users to transfer several wrapped tokens, including:
 
 For the Etherlink addresses of these tokens, see [Token addresses](#token-addresses).
 
-## Using the wrapped asset bridge
+## Using the EVM bridge
 
 For a video walkthrough of the bridge, see this video:
 
 <Video src="https://www.loom.com/embed/6a1bb548a5c7439fafdb328b4785adca?sid=bfeed550-9191-4fea-b274-453ff1f1caf9"/>
 
-![Overview of the wrapped asset bridge](/img/wab-details.png)
+![Overview of the EVM bridge](/img/wab-details.png)
 
-1. Go to the Etherlink wrapped asset bridge at https://www.etherlinkbridge.com/bridge.
+1. Go to the Etherlink EVM bridge at https://www.etherlinkbridge.com/bridge.
 
 1. Click the **Connect** button and connect your EVM wallet.
 
@@ -367,7 +367,7 @@ These tables show the addresses of the equivalent tokens on other networks:
 
 ## How bridging wrapped assets works
 
-The Etherlink wrapped asset bridge uses a [wrapped asset bridge](https://github.com/LayerZero-Labs/wrapped-asset-bridge) created by [LayerZero](https://layerzero.network/).
+The Etherlink EVM bridge uses a [wrapped asset bridge](https://github.com/LayerZero-Labs/wrapped-asset-bridge) created by [LayerZero](https://layerzero.network/).
 It works by maintaining liquidity pools on other networks and minting equivalent tokens on Etherlink.
 
 When you bridge tokens from other networks to Etherlink, the bridge contracts lock the tokens in a liquidity pool on the source network, send a message over LayerZero's software to Etherlink, and mint tokens on Etherlink.
@@ -375,9 +375,9 @@ When you bridge tokens out of Etherlink, the contracts burn the tokens on Etherl
 Therefore, bridging tokens out of Etherlink is dependent on the liquidity pool on the target chain.
 LayerZero also maintains Etherlink EVM and Smart Rollup nodes to verify that the transactions complete on Etherlink.
 
-This diagram shows how the wrapped asset bridge works:
+This diagram shows how the EVM bridge works:
 
-![Overview of the wrapped asset bridge, showing the interaction between contracts on other chains and Etherlink, moderated by LayerZero](/img/wrapped-asset-bridge.png)
+![Overview of the EVM bridge, showing the interaction between contracts on other chains and Etherlink, moderated by LayerZero](/img/wrapped-asset-bridge.png)
 {/* https://lucid.app/lucidchart/cac80916-85c8-455d-b50b-f265057dcc1b/edit */}
 
 For more information, see the repository for the bridge: https://github.com/LayerZero-Labs/wrapped-asset-bridge.
@@ -388,4 +388,4 @@ For more information, see the repository for the bridge: https://github.com/Laye
 - For information about Etherlink transactions, see the [Etherlink block explorer](https://explorer.etherlink.com/).
 - More Information about the LayerZero protocol is available in their [official documentation](https://docs.layerzero.network/).
 - The audit reports of the LayerZero protocol are available in this [LayerZero GitHub Repository](https://github.com/LayerZero-Labs/LayerZero/tree/main/audit).
-- To review the open source code of the wrapped asset bridge, visit the [LayerZero Github Repository](https://github.com/LayerZero-Labs/wrapped-asset-bridge).
+- To review the open source code of the EVM bridge, visit the [LayerZero Github Repository](https://github.com/LayerZero-Labs/wrapped-asset-bridge).

--- a/docs/bridging/bridging-tezos.md
+++ b/docs/bridging/bridging-tezos.md
@@ -62,7 +62,7 @@ To use the Testnet bridge, follow these general steps:
 
 You can monitor the status of your bridge operations on the **Transaction History** tab.
 
-### How bridging XTZ works
+## How bridging XTZ works
 
 The process of bridging XTZ between Etherlink and Tezos layer 1 uses two contracts on Tezos layer 1:
 

--- a/docs/bridging/bridging-tezos.md
+++ b/docs/bridging/bridging-tezos.md
@@ -6,11 +6,11 @@ You can bridge the native token on Etherlink and Tezos, which is called tez and 
 You can bridge tez from Tezos Mainnet to XTZ on Etherlink Mainnet and back, and you can bridge tez from Tezos Testnet (Ghostnet) to XTZ on Etherlink Testnet and back.
 For more information about tez, see [Tokens](https://docs.tezos.com/architecture/tokens) on docs.tezos.com.
 
-Etherlink provides canonical bridges for XTZ tokens.
+Etherlink provides Tezos bridges for XTZ tokens.
 These bridges are trustless and permissionless; anyone can use them without restrictions or the intervention of a third party.
 
-- [Mainnet canonical bridge](https://bridge.etherlink.com/)
-- [Testnet canonical bridge](https://testnet.bridge.etherlink.com/)
+- [Mainnet Tezos bridge](https://www.etherlinkbridge.com/tezos-bridge)
+- [Testnet Tezos bridge](https://testnet.bridge.etherlink.com/)
 
 - Bridging tokens from Tezos layer 1 to Etherlink is referred to as _depositing_ tokens.
 - Bridging tokens from Etherlink to Tezos layer 1 is referred to as _withdrawing_ tokens.
@@ -26,7 +26,7 @@ This delay is caused by the Smart Rollup refutation period. As with all Smart Ro
 The Etherlink indexer run by Nomadic Labs automatically executes these bridging transactions when they are cemented, which makes the bridged tokens available on Tezos.
 :::
 
-## Using the canonical bridges
+## Using the Tezos bridges
 
 To use these bridges, follow these general steps:
 

--- a/docs/bridging/bridging-tezos.md
+++ b/docs/bridging/bridging-tezos.md
@@ -26,11 +26,31 @@ This delay is caused by the Smart Rollup refutation period. As with all Smart Ro
 The Etherlink indexer run by Nomadic Labs automatically executes these bridging transactions when they are cemented, which makes the bridged tokens available on Tezos.
 :::
 
-## Using the Tezos bridges
+## Using the Mainnet Tezos bridge
 
-To use these bridges, follow these general steps:
+To use the Mainnet bridge, follow these general steps:
+
+1. Go to the bridge at https://www.etherlinkbridge.com/tezos-bridge.
 
 1. Connect your Tezos and Etherlink-compatible wallets.
+
+1. Select the type of transfer:
+
+   - **Deposit** transfers XTZ from Tezos layer 1 to Etherlink
+   - **Withdraw** transfers XTZ from Etherlink to Tezos layer 1
+
+1. Enter the amount of XTZ tokens to transfer.
+
+1. Click **Transfer**.
+
+## Using the Testnet Tezos bridge
+
+To use the Testnet bridge, follow these general steps:
+
+1. Go to the bridge at https://testnet.bridge.etherlink.com.
+
+1. Connect your Tezos and Etherlink-compatible wallets.
+
 1. Select the type of transfer:
 
    - **Deposit** transfers XTZ from Tezos layer 1 to Etherlink

--- a/docs/bridging/bridging.mdx
+++ b/docs/bridging/bridging.mdx
@@ -28,13 +28,13 @@ These bridges are trustless and permissionless; anyone can use them without rest
   </thead>
   <tbody>
     <tr>
-      <td>Canonical bridge</td>
-      <td>Bridges XTZ tokens from Tezos layer 1 to Etherlink and back></td>
-      <td><a href="https://bridge.etherlink.com/" target="_blank" rel="noopener noreferrer">Mainnet</a></td>
+      <td>Tezos bridge</td>
+      <td>Bridges XTZ tokens from Tezos layer 1 to Etherlink and back</td>
+      <td><a href="https://www.etherlinkbridge.com/tezos-bridge" target="_blank" rel="noopener noreferrer">Mainnet</a></td>
       <td><a href="https://testnet.bridge.etherlink.com/" target="_blank" rel="noopener noreferrer">Testnet</a></td>
     </tr>
     <tr>
-      <td>Wrapped asset bridge</td>
+      <td>EVM bridge</td>
       <td>Bridges assets from EVM chains to wrapped assets on Etherlink and back</td>
       <td><a href="https://www.etherlinkbridge.com/bridge" target="_blank" rel="noopener noreferrer">Mainnet</a></td>
       <td>Not available on Etherlink Testnet</td>

--- a/sidebars.js
+++ b/sidebars.js
@@ -39,13 +39,8 @@ const sidebars = {
       collapsed: false,
       items: [
         'bridging/bridging',
-<<<<<<< HEAD
         'bridging/bridging-tezos',
         'bridging/bridging-evm',
-=======
-        'bridging/bridging-xtz',
-        'bridging/bridging-wrapped-assets',
->>>>>>> 4f74a4b (Move bridging to its own section)
       ],
     },
     {

--- a/sidebars.js
+++ b/sidebars.js
@@ -39,8 +39,13 @@ const sidebars = {
       collapsed: false,
       items: [
         'bridging/bridging',
+<<<<<<< HEAD
         'bridging/bridging-tezos',
         'bridging/bridging-evm',
+=======
+        'bridging/bridging-xtz',
+        'bridging/bridging-wrapped-assets',
+>>>>>>> 4f74a4b (Move bridging to its own section)
       ],
     },
     {


### PR DESCRIPTION
The bridges are getting consolidated  on https://www.etherlinkbridge.com. Update URLs and UI instructions to match.

Depends on https://github.com/etherlinkcom/docs/pull/184.