### PR TITLE
Add changelog to resources section of the sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -115,6 +115,11 @@ const sidebars = {
       items: [
         'resources/etherlink-further-reading',
         'resources/scaling-on-tezos',
+        {
+          type: 'link',
+          label: 'Changelog',
+          href: 'https://gitlab.com/tezos/tezos/-/blob/master/etherlink/CHANGES_KERNEL.md',
+        },
       ],
     },
   ],


### PR DESCRIPTION
Is this a good place for a link to the changelog?
<img width="347" alt="Screenshot 2024-11-06 at 2 19 32 PM" src="https://github.com/user-attachments/assets/423b539b-311b-42e6-8ceb-02df6e8a0f26">
