### PR TITLE
Show icons on only the items at the top of the sidebar

### DIFF
--- a/src/theme/DocSidebarItem/Link/index.tsx
+++ b/src/theme/DocSidebarItem/Link/index.tsx
@@ -39,7 +39,7 @@ export default function DocSidebarItemLink({
       )}
       style={{
         margin: `${item.label === 'Etherlink' && '40px 0px'}`,
-        marginBottom: `${!isInternalLink && index === 3 && '40px'}`,
+        marginBottom: `${!isInternalLink && isTopSection(item.label) && index === 3 && '40px'}`,
       }}
       key={label}>
       <Link
@@ -64,10 +64,10 @@ export default function DocSidebarItemLink({
         }}
         {...props}>
         <div className={styles.leftHand}>
-          {!isInternalLink && <img src={ICONS_PATH[index]} alt='external link icon' />}
+          {!isInternalLink && isTopSection(item.label) && <img src={ICONS_PATH[index]} alt='external link icon' />}
           {label}
         </div>
-        {!isInternalLink && <img src='/img/FiArrowUpRight.svg' alt='external link icon' />}
+        {!isInternalLink && isTopSection(item.label) && <img src='/img/FiArrowUpRight.svg' alt='external link icon' />}
       </Link>
     </li>
   );


### PR DESCRIPTION
We have custom styling to put icons on the links at the top of the sidebar. Due to the selectors being too general, those icons are also being applied to items in the Track Progress section. This focuses the selectors so those items are not in the Track Progress section.

Before:
![Screenshot 2024-11-14 at 10 54 21 AM](https://github.com/user-attachments/assets/8909eeff-0bfe-4f17-96bd-c98ab1d0b7d5)

After:

![Screenshot 2024-11-14 at 10 54 43 AM](https://github.com/user-attachments/assets/568c7f67-5992-4ea9-8397-f414b01fa11a)


