### PR TITLE
Fixed testnet exchanger address, corrected exchanger contract name

### DIFF
--- a/docs/bridging/bridging-tezos.md
+++ b/docs/bridging/bridging-tezos.md
@@ -61,8 +61,8 @@ This bridge contract is not a fundamental part of the bridge; it is a helper con
 - An exchanger contract that stores the tokens and issues tickets that represent those tokens.
 This contract is a fundamental part of the bridging process because Etherlink accepts tickets from only this contract for the purpose of bridging XTZ.
 
-  - The source code of this contract is in [`evm_bridge.mligo`](https://gitlab.com/tezos/tezos/-/blob/master/etherlink/tezos_contracts/exchanger.mligo).
-  - This contract is deployed to testnet at [`KT1VEjeQfDBSfpDH5WeBM5LukHPGM2htYEh3`](https://ghostnet.tzkt.io/KT1VEjeQfDBSfpDH5WeBM5LukHPGM2htYEh3/).
+  - The source code of this contract is in [`exchanger.mligo`](https://gitlab.com/tezos/tezos/-/blob/master/etherlink/tezos_contracts/exchanger.mligo).
+  - This contract is deployed to testnet at [`KT1Bp9YUvUBJgXxf5UrYTM2CGRUPixURqx4m`](https://ghostnet.tzkt.io/KT1Bp9YUvUBJgXxf5UrYTM2CGRUPixURqx4m/).
   - This contract is deployed to Mainnet at [`KT1CeFqjJRJPNVvhvznQrWfHad2jCiDZ6Lyj`](https://tzkt.io/KT1CeFqjJRJPNVvhvznQrWfHad2jCiDZ6Lyj/).
 
 ### Deposit process


### PR DESCRIPTION
Fixed the testnet exchanger address, which can be found in the storage of the [evm_bridge](https://ghostnet.tzkt.io/KT1VEjeQfDBSfpDH5WeBM5LukHPGM2htYEh3/storage/) contract.

Corrected the contract name: previously, both the `exchanger` and `evm_bridge` contracts shared the same `evm_bridge` name.