### PR TITLE
Add some more space for the page outline

### DIFF
--- a/src/theme/TOC/styles.module.css
+++ b/src/theme/TOC/styles.module.css
@@ -2,7 +2,7 @@
   max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem));
   overflow-y: auto;
   position: sticky;
-  top: calc(var(--ifm-navbar-height) + 1rem);
+  top: calc(var(--ifm-navbar-height) + 2rem);
 }
 @media screen and (min-width: 1440px){
   .tableOfContents {


### PR DESCRIPTION
The page outline in the right column is sticky, so it stays at the top of the page. However, there is not enough padding, so as you scroll down it gets partially blurred by the top blur area. This adds some more padding so it appears clearly.

Before:
<img width="520" alt="Screenshot 2025-01-02 at 10 58 16 AM" src="https://github.com/user-attachments/assets/bdab1910-cd1e-4856-a3ed-aed5bedd220f" />

After:
<img width="475" alt="Screenshot 2025-01-02 at 10 58 27 AM" src="https://github.com/user-attachments/assets/3c5ec6af-e8f4-40e5-ad8d-a02014682a75" />
