### PR TITLE
Reuse book icon for tutorial

### DIFF
--- a/src/theme/DocSidebarItem/Category/index.tsx
+++ b/src/theme/DocSidebarItem/Category/index.tsx
@@ -104,7 +104,7 @@ function CollapseButton({
   );
 }
 
-const ITEMICONS = ['/img/FiHome.svg', '/img/BiSortAlt2.svg', '/img/FiBox.svg', '/img/FiWifi.svg', '/img/FiSettings.svg', '/img/FiUsers.svg', '/img/FiTrendingUp.svg', '/img/FiBookOpen.svg']
+const ITEMICONS = ['/img/FiHome.svg', '/img/FiBookOpen.svg', '/img/BiSortAlt2.svg', '/img/FiBox.svg', '/img/FiWifi.svg', '/img/FiSettings.svg', '/img/FiUsers.svg', '/img/FiTrendingUp.svg', '/img/FiBookOpen.svg']
 
 export default function DocSidebarItemCategory({
   item,


### PR DESCRIPTION
This adds the book icon for tutorials in the sidebar:

![Screenshot 2025-01-10 at 10 42 10 AM](https://github.com/user-attachments/assets/00fb9525-4a97-4300-ad6a-af21f2a53768)
