### PR TITLE
EVM node can import a snapshot automatically

### DIFF
--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -59,10 +59,10 @@ You can initialize the node from a snapshot or allow it to compute the Etherlink
 
 ### From a snapshot
 
-To automatically download and import a snapshot, start the node with the `--init-from-snapshot` switch, as in this example:
+To automatically download and import a snapshot, start the node with the `--init-from-snapshot` switch and the network, as in this example:
 
 ```bash
-octez-evm-node run observer --data-dir $evm_observer_dir
+octez-evm-node run observer --data-dir $evm_observer_dir --network testnet --init-from-snapshot
 ```
 
 The node can take time to download and import the snapshot.

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -59,18 +59,26 @@ You can initialize the node from a snapshot or allow it to compute the Etherlink
 
 ### From a snapshot
 
-1. Download [an Etherlink snapshot](http://snapshotter-sandbox.nomadic-labs.eu/), and use the `octez-evm-node` to import it.
+To automatically download and import a snapshot, start the node with the `--init-from-snapshot` switch, as in this example:
 
-   ```bash
-   wget http://snapshotter-sandbox.nomadic-labs.eu/etherlink-mainnet/evm-snapshot-sr1Ghq66tYK9y-latest.gz # this is for the latest mainnet etherlink snapshots, similarly there is one for testnet
-   octez-evm-node snapshot import evm-snapshot-sr1Ghq66tYK9y-latest.gz --data-dir $evm_observer_dir
+```bash
+octez-evm-node run observer --data-dir $evm_observer_dir
+```
 
-   ```
-2. Run this command to start the node:
+The node can take time to download and import the snapshot.
 
-   ```bash
-   octez-evm-node run observer --data-dir $evm_observer_dir
-   ```
+To import the snapshot manually, download the snapshot from http://snapshotter-sandbox.nomadic-labs.eu/ and import it with this command:
+
+```bash
+wget http://snapshotter-sandbox.nomadic-labs.eu/etherlink-mainnet/evm-snapshot-sr1Ghq66tYK9y-latest.gz # this is for the latest mainnet etherlink snapshots, similarly there is one for testnet
+octez-evm-node snapshot import evm-snapshot-sr1Ghq66tYK9y-latest.gz --data-dir $evm_observer_dir
+```
+
+Then, run this command to start the node:
+
+```bash
+octez-evm-node run observer --data-dir $evm_observer_dir
+```
 
 By default, the EVM node exposes its JSON RPC API endpoint to `localhost:8545`.
 You can test that everything works as expected by running RPC requests manually or by setting your wallet to use your local node.

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -80,14 +80,6 @@ Then, run this command to start the node:
 octez-evm-node run observer --data-dir $evm_observer_dir
 ```
 
-By default, the EVM node exposes its JSON RPC API endpoint to `localhost:8545`.
-You can test that everything works as expected by running RPC requests manually or by setting your wallet to use your local node.
-For example, this command gets the number of the most recent block in hexadecimal:
-
-```bash
-curl -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber"}' http://localhost:8545
-```
-
 ### From an existing Etherlink Smart Rollup node
 
 1. Download [an Etherlink Smart Rollup node snapshot](https://snapshots.eu.tzinit.org/etherlink-ghostnet/), and use the `octez-smart-rollup-node` binary to import it in a temporary directory.
@@ -119,14 +111,6 @@ curl -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","metho
 
    The EVM node runs in archive mode.
 
-By default, the EVM node exposes its JSON RPC API endpoint to `localhost:8545`.
-You can test that everything works as expected by running RPC requests manually or by setting your wallet to use your local node.
-For example, this command gets the number of the most recent block in hexadecimal:
-
-```bash
-curl -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber"}' http://localhost:8545
-```
-
 ### From genesis
 
 1. Get the Etherlink installer kernel (`installer.hex` file), which you can build yourself as described in [Building the Etherlink kernel](/network/building-kernel) or download here: [installer.hex](/files/installer.hex).
@@ -138,10 +122,20 @@ curl -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","metho
 
    The `--initial-kernel` argument is needed only the first time that you start the node.
 
+## Verifying that the node is running
+
+When the node is running, its log shows information about the blocks it receives from the sequencer (referred to here as _blueprints_), as in this example:
+
+```
+Jan 15 20:17:23.794: Applied a blueprint for level 16867349 at 2025-01-15T19:38:35Z containing 1
+Jan 15 20:17:23.794:   transactions for 2814041 gas leading to creating block
+Jan 15 20:17:23.794:   0xeb720c1c5df94f820d4ede15ddef92b9267d1291dea15a716a160b4c2[...] in 245ms.
+```
+
 By default, the EVM node exposes its JSON RPC API endpoint to `localhost:8545`.
 You can test that everything works as expected by running RPC requests manually or by setting your wallet to use your local node.
-For example, you can call the node's RPC API with this command, putting the URL to your EVM node at the end:
+For example, this command gets the number of the most recent block in hexadecimal:
 
 ```bash
-curl -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"tez_kernelVersion"}' http://localhost:8545
+curl -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber"}' http://localhost:8545
 ```

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -59,7 +59,7 @@ You can initialize the node from a snapshot or allow it to compute the Etherlink
 
 ### From a snapshot
 
-To automatically download and import a snapshot, start the node with the `--init-from-snapshot` switch and the network, as in this example:
+To automatically download and import a snapshot, start the node with the `--init-from-snapshot` switch and the network to use ("mainnet" or "testnet"), as in this example:
 
 ```bash
 octez-evm-node run observer --data-dir $evm_observer_dir --network testnet --init-from-snapshot
@@ -74,10 +74,10 @@ wget http://snapshotter-sandbox.nomadic-labs.eu/etherlink-mainnet/evm-snapshot-s
 octez-evm-node snapshot import evm-snapshot-sr1Ghq66tYK9y-latest.gz --data-dir $evm_observer_dir
 ```
 
-Then, run this command to start the node:
+Then, run this command to start the node, passing the data directory and the network to use ("mainnet" or "testnet"):
 
 ```bash
-octez-evm-node run observer --data-dir $evm_observer_dir
+octez-evm-node run observer --network testnet --data-dir $evm_observer_dir
 ```
 
 ### From an existing Etherlink Smart Rollup node

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -87,6 +87,8 @@ octez-evm-node snapshot import evm-snapshot-sr1Ghq66tYK9y-latest.gz \
   --data-dir $evm_observer_dir
 ```
 
+You can also pass the URL of the snapshot directly to the `octez-evm-node snapshot import` command.
+
 Then, run this command to start the node, passing the data directory and the network to use:
 
 ```bash

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -30,39 +30,51 @@ These images contain the correct version of the binary.
 1. If you want your EVM node to check the correctness of the blocks it receives via a Smart Rollup node, set the `sr_node_observer_rpc` environment variable to the URL of that Etherlink Smart Rollup node, such as `http://localhost:8932`.
 1. Set the `evm_observer_dir` environment variable to the directory where the node should store its local data.
 The default is `$HOME/.octez-evm-node`.
-1. Initialize the node. To trust incoming blocks, use `--dont-track-rollup-node`:
+1. Initialize the node by setting the data directory in the `--data-dir` argument and the network to use (such as `mainnet` or `testnet`) in the `--network` argument.
+
+   To trust incoming blocks, use `--dont-track-rollup-node`:
 
    ```bash
    octez-evm-node init config \
-     --data-dir $evm_observer_dir --dont-track-rollup-node \
-     --preimages-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0 \
-     --evm-node-endpoint https://relay.mainnet.etherlink.com
+     --network mainnet \
+     --data-dir $evm_observer_dir \
+     --dont-track-rollup-node
    ```
 
-   Alternatively, if you want to rely on a Smart Rollup node to check the correctness of blocks coming from the sequencer, use `--rollup-node-endpoint`:
+   Alternatively, if you want to rely on a Smart Rollup node to check the correctness of blocks coming from the sequencer, pass the `sr_node_observer_rpc` environment variable to the `--rollup-node-endpoint` argument:
 
    ```bash
    octez-evm-node init config \
-     --data-dir $evm_observer_dir --rollup-node-endpoint $sr_node_observer_rpc \
-     --preimages-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0 \
-     --evm-node-endpoint https://relay.mainnet.etherlink.com
+     --network mainnet \
+     --data-dir $evm_observer_dir \
+     --rollup-node-endpoint $sr_node_observer_rpc
    ```
 
-   This configuration uses the preimages that the Tezos Foundation hosts on a file server on a so-called "preimages endpoint".
+   The `--network` argument sets the node to use preimages that the Tezos Foundation hosts on a file server on a so-called "preimages endpoint".
+   For example, passing `--network mainnet` implies these arguments:
+
+   ```bash
+   --preimages-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0 \
+   --evm-node-endpoint https://relay.mainnet.etherlink.com
+   ```
+
    It's safe to use these preimages because the node verifies them.
    If you don't want to use third-party preimages, you can build the kernel yourself and move the contents of the `wasm_2_0_0/` directory to the local data directory; see [Building the Etherlink kernel](/network/building-kernel).
    However, in this case, you must manually update this directory with the preimages of every kernel voted by the community and deployed on Etherlink after that.
 
 ## Running the node
 
-You can initialize the node from a snapshot or allow it to compute the Etherlink state from genesis, which can take a long time.
+You can initialize the node from a snapshot, initialize it from an existing Etherlink Smart Rollup node, or allow it to compute the Etherlink state from genesis.
 
 ### From a snapshot
 
-To automatically download and import a snapshot, start the node with the `--init-from-snapshot` switch and the network to use ("mainnet" or "testnet"), as in this example:
+To automatically download and import a snapshot, start the node with the `--init-from-snapshot` switch and the network to use, as in this example:
 
 ```bash
-octez-evm-node run observer --data-dir $evm_observer_dir --network testnet --init-from-snapshot
+octez-evm-node run observer \
+  --data-dir $evm_observer_dir \
+  --network testnet \
+  --init-from-snapshot
 ```
 
 The node can take time to download and import the snapshot.
@@ -71,13 +83,16 @@ To import the snapshot manually, download the snapshot from http://snapshotter-s
 
 ```bash
 wget http://snapshotter-sandbox.nomadic-labs.eu/etherlink-mainnet/evm-snapshot-sr1Ghq66tYK9y-latest.gz # this is for the latest mainnet etherlink snapshots, similarly there is one for testnet
-octez-evm-node snapshot import evm-snapshot-sr1Ghq66tYK9y-latest.gz --data-dir $evm_observer_dir
+octez-evm-node snapshot import evm-snapshot-sr1Ghq66tYK9y-latest.gz \
+  --data-dir $evm_observer_dir
 ```
 
-Then, run this command to start the node, passing the data directory and the network to use ("mainnet" or "testnet"):
+Then, run this command to start the node, passing the data directory and the network to use:
 
 ```bash
-octez-evm-node run observer --network testnet --data-dir $evm_observer_dir
+octez-evm-node run observer \
+  --network testnet \
+  --data-dir $evm_observer_dir
 ```
 
 ### From an existing Etherlink Smart Rollup node


### PR DESCRIPTION
- You can start a node and import a snapshot automatically by running it with `--init-from-snapshot`
- Extract a section on verifying that the node is running instead of duplicating the info