### PR TITLE
Link to system requirements for Octez

### DIFF
--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -13,6 +13,9 @@ Public Smart Rollup nodes for Etherlink are not yet available, so you must run y
 The EVM node runs Etherlink's kernel.
 You can get the kernel by importing it from a running Etherlink Smart Rollup node or by providing the installer kernel.
 
+The Etherlink EVM node is part of Octez suite.
+See this page for system requirements for the latest release of the Octez suite: https://tezos.gitlab.io/releases/latest.html.
+
 ## System requirements
 
 Running an Etherlink EVM node on Etherlink Mainnet requires a computer with 500GB of disk space and at least 16GB RAM.

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -9,6 +9,7 @@ Public Smart Rollup nodes for Etherlink are not yet available, so you must run y
 
 In this context, an _Etherlink Smart Rollup node_ is an [Octez Smart Rollup node](https://tezos.gitlab.io/shell/smart_rollup_node.html) that runs the Etherlink kernel.
 This kernel is a Rust program compiled in WASM implementing the semantics of Etherlink blocks and transactions.
+For system requirements, see the documentation for the latest release of the Octez suite here: https://tezos.gitlab.io/releases/latest.html.
 
 :::
 


### PR DESCRIPTION
The link https://tezos.gitlab.io/releases/latest.html should always link to information for the current release of Octez.