### PR TITLE
network information: update snapshots link

### DIFF
--- a/docs/get-started/network-information.mdx
+++ b/docs/get-started/network-information.mdx
@@ -60,9 +60,17 @@ You can [set up your own node](/network/evm-nodes) if you need an endpoint witho
       <td>Block Explorer URL</td>
       <td><a href="https://explorer.etherlink.com">https://explorer.etherlink.com</a></td>
     </tr>
-      <tr>
-      <td>Snapshot and preimages site</td>
+    <tr>
+      <td>Etherlink smart rollup snapshots</td>
       <td><a href="https://snapshots.eu.tzinit.org/etherlink-mainnet/">https://snapshots.eu.tzinit.org/etherlink-mainnet/</a></td>
+    </tr>
+    <tr>
+      <td>Etherlink EVM node snapshots</td>
+      <td><a href="https://snapshotter-sandbox.nomadic-labs.eu/etherlink-mainnet/">https://snapshotter-sandbox.nomadic-labs.eu/etherlink-mainnet/</a></td>
+    </tr>
+    <tr>
+      <td>Pre-images</td>
+      <td><a href="https://snapshots.tzinit.org/etherlink-mainnet/wasm_2_0_0">https://snapshots.tzinit.org/etherlink-mainnet/wasm_2_0_0</a></td>
     </tr>
   </tbody>
 </table>
@@ -110,8 +118,16 @@ You can [set up your own node](/network/evm-nodes) if you need an endpoint witho
       <td><a href="https://testnet.explorer.etherlink.com/">https://testnet.explorer.etherlink.com/</a></td>
     </tr>
     <tr>
-      <td>Snapshot and preimages site</td>
+      <td>Etherlink smart rollup snapshots</td>
       <td><a href="https://snapshots.eu.tzinit.org/etherlink-ghostnet/">https://snapshots.eu.tzinit.org/etherlink-ghostnet/</a></td>
+    </tr>
+    <tr>
+      <td>Etherlink EVM node snapshots</td>
+      <td><a href="https://snapshotter-sandbox.nomadic-labs.eu/etherlink-ghostnet/">https://snapshotter-sandbox.nomadic-labs.eu/etherlink-ghostnet/</a></td>
+    </tr>
+    <tr>
+      <td>Pre-images</td>
+      <td><a href="https://snapshots.tzinit.org/etherlink-ghostnet/wasm_2_0_0">https://snapshots.tzinit.org/etherlink-ghostnet/wasm_2_0_0</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Add the EVM snapshots link to the network information pages and rename link for rollup node snapshots.