### PR TITLE
Remove node providers page

### DIFF
--- a/docs/tools/node-providers.md
+++ b/docs/tools/node-providers.md
@@ -1,7 +1,0 @@
----
-title: Node providers
----
-
-## Zeeve
-
-[Zeeve](https://www.zeeve.io/) provides public and private RPC endpoints for Etherlink, along with websocket support. They also allow you to launch your own dedicated node in just a few clicks!

--- a/sidebars.js
+++ b/sidebars.js
@@ -92,7 +92,6 @@ const sidebars = {
       label: 'Tools',
       collapsed: false,
       items: [
-        'tools/node-providers',
         'tools/price-feeds',
         'tools/vrf',
         'tools/data-indexers',


### PR DESCRIPTION
Zeeve no longer provides Etherlink nodes.