### PR TITLE
History modes and snapshots in EVM node 0.19

### DIFF
--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -98,11 +98,9 @@ These snapshots are equivalent to the mode `rolling:1` or `full:1`.
 
 If you want a mode with a longer retention period, you can:
 
-- Specify the same mode with a longer retention period when you run the node.
-In this case the node does not immediately retrieve the new data, but continues to store data until it has enough for the specified retention period.
 - Download an older snapshot and allow the EVM node to compute the data since the snapshot was taken.
 - Create your own snapshot with the appropriate retention period from another EVM node.
-- Start with a node in a mode that has the necessary data (such as `archive` mode) and switch to another mode with the retention period that you want.
+- Start with a node in a mode that has the necessary data and [switch to another mode](#switching-history-modes) with the retention period that you want.
 
 To download and import the snapshot manually, download the appropriate snapshot for the network and mode (such as from http://snapshotter-sandbox.nomadic-labs.eu/) and import it with the `octez-evm-node snapshot import` command, as in this example:
 
@@ -141,6 +139,9 @@ octez-evm-node run observer \
   --data-dir <EVM_DATA_DIR> \
   --init-from-snapshot
 ```
+
+The `--history` argument is required in this case to tell the node what snapshot to download.
+However, an appropriate snapshot must be available on the [Nomadic Labs snapshot site](http://snapshotter-sandbox.nomadic-labs.eu/).
 
 The node can take time to download and import the snapshot.
 

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -26,7 +26,6 @@ The EVM node supports these history modes:
 - `full` (available starting with version 0.17): The node stores all of the necessary information to construct the current Etherlink state plus the states for a certain number of previous days, known as the _retention period_.
 
 - `rolling` (available starting with version 0.16): The node stores the current context plus the complete transaction data for a certain number of previous days, known as the _retention period_.
-The default `rolling` mode stores the complete data for the previous 14 days.
 
 The Octez EVM node history modes follow the same semantics as the Octez layer 1 node history modes.
 For more information about modes, see [History modes](https://octez.tezos.com/docs/user/history_modes.html) in the Octez documentation.

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -98,9 +98,11 @@ These snapshots are equivalent to the mode `rolling:1` or `full:1`.
 
 If you want a mode with a longer retention period, you can:
 
-- Download an older snapshot and allow the EVM node to compute the data since the snapshot was taken
-- Create your own snapshot with the appropriate retention period
-- Start with a node in a mode that has the necessary data (such as `archive` mode) and switch to another mode with the retention period that you need
+- Specify the same mode with a longer retention period when you run the node.
+In this case the node does not immediately retrieve the new data, but continues to store data until it has enough for the specified retention period.
+- Download an older snapshot and allow the EVM node to compute the data since the snapshot was taken.
+- Create your own snapshot with the appropriate retention period from another EVM node.
+- Start with a node in a mode that has the necessary data (such as `archive` mode) and switch to another mode with the retention period that you want.
 
 To download and import the snapshot manually, download the appropriate snapshot for the network and mode (such as from http://snapshotter-sandbox.nomadic-labs.eu/) and import it with the `octez-evm-node snapshot import` command, as in this example:
 

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -52,6 +52,11 @@ The following instructions use the variable `<EVM_DATA_DIR>` to represent this d
      --rollup-node-endpoint <SR_NODE_OBSERVER_RPC>
    ```
 
+   By default, the node uses the `archive` history mode, which stores a copy of all Etherlink information.
+   To save disk space, starting with version 0.16, you can use the `rolling` history mode by passing the argument `--history-mode rolling:<DAYS>`, where `<DAYS>` is the number of days of complete data to keep.
+   The default for `rolling` history mode is 14 days.
+   You can switch the mode from `archive` mode to `rolling` mode later by stopping the node and running the command `octez-evm-node switch history to rolling`.
+
    The `--network` argument sets the node to use preimages that the Tezos Foundation hosts on a file server on a so-called "preimages endpoint".
    For example, passing `--network mainnet` implies these arguments:
 

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -207,7 +207,7 @@ Because the node cannot reconstruct data that it does not have, you can switch f
 When you switch from `full` or `rolling` mode and change the retention period, the node can increase the retention period, but it does not immediately retrieve the new data.
 For example, you can switch from `rolling:1` mode to `rolling:5` mode, but the node does not immediately download the previous 5 days of data.
 Instead, it begins storing more data as time passes until it has enough for 5 days of history.
-You can also start a node in `rolling:5` mode by downloading a rolling snapshot that is 5 days old or by switching from `archive` mode or `full` mode.
+You can also start a node in `rolling:5` mode by downloading a rolling snapshot that is 5 days old or by switching from `archive` mode.
 
 Switching modes can increase the size of the data directory, so be sure that the node has enough disk space before switching.
 For example, switching from another mode to `rolling` mode requires more space than starting a new node in `rolling` mode from a new data directory with the same retention period.

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -211,7 +211,7 @@ Instead, it begins storing more data as time passes until it has enough for 5 da
 You can also start a node in `rolling:5` mode by downloading a rolling snapshot that is 5 days old or by switching from `archive` mode or `full` mode.
 
 Switching modes can increase the size of the data directory, so be sure that the node has enough disk space before switching.
-For example, switching from another mode to `rolling` mode requires more space than starting a node in `rolling` mode with the same retention period.
+For example, switching from another mode to `rolling` mode requires more space than starting a new node in `rolling` mode from a new data directory with the same retention period.
 
 ## Verifying that the node is running
 

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -23,20 +23,15 @@ The EVM node supports these history modes:
 
 - `archive` (the default): The node stores a copy of all available Etherlink information.
 
-- `full` (available starting with version 0.17): The node stores all of the necessary information to construct the current Etherlink state.
+- `full` (available starting with version 0.17): The node stores all of the necessary information to construct the current Etherlink state plus the states for a certain number of previous days, known as the _retention period_.
 
-- `rolling` (available starting with version 0.16): The node stores the current context plus the complete transaction data for a certain number of previous days.
+- `rolling` (available starting with version 0.16): The node stores the current context plus the complete transaction data for a certain number of previous days, known as the _retention period_.
 The default `rolling` mode stores the complete data for the previous 14 days.
 
+The Octez EVM node history modes follow the same semantics as the Octez layer 1 node history modes.
 For more information about modes, see [History modes](https://octez.tezos.com/docs/user/history_modes.html) in the Octez documentation.
 
-You can switch from the other modes to `rolling` mode or `full` mode with the command `octez-evm-node switch history to <MODE>`, where `<MODE>` is the new mode.
-You cannot switch from another mode to `archive` mode; to set up an archive node, you must start with an `archive` mode snapshot.
-
-For example, you can switch to `rolling` mode with the command `octez-evm-node switch history to rolling:<DAYS>`, where `<DAYS>` is the number of days of compete data to keep.
-If you use this command to store more days of rolling data, such as switching from `rolling:1` to `rolling:5`, the node does not immediately download the previous 5 days of data.
-Instead, it begins storing complete data, so after 5 days it has enough data to be in `rolling:5` mode.
-You can also start a node in `rolling:5` mode by downloading a rolling snapshot that is 5 days old or by switching from `archive` mode or `full` mode.
+To switch modes, see [Switching modes](#switching-modes).
 
 ## Getting the `octez-evm-node` binary
 
@@ -98,12 +93,16 @@ You can import a snapshot into the EVM node in any of these ways:
 - Allow the node to download the snapshot automatically
 
 You must download the appropriate snapshot for the network and mode.
-Rolling and full snapshots include 1 day of complete data.
-Therefore the rolling snapshot is equivalent to the mode `rolling:1`.
-If you want a longer rolling mode, you can download an older snapshot and the EVM node computes the complete data since the snapshot was taken.
-You can also start with a node in another mode and switch to rolling mode with any number of days of complete data.
+Rolling and full snapshots provided on the [Nomadic Labs snapshot site](http://snapshotter-sandbox.nomadic-labs.eu/) include 1 day of complete data.
+These snapshots are equivalent to the mode `rolling:1` or `full:1`.
 
-To download and import the snapshot manually, download the appropriate snapshot for the network and mode from http://snapshotter-sandbox.nomadic-labs.eu/ and import it with this command:
+If you want a mode with a longer retention period, you can:
+
+- Download an older snapshot and allow the EVM node to compute the data since the snapshot was taken
+- Create your own snapshot with the appropriate retention period
+- Start with a node in a mode that has the necessary data (such as `archive` mode) and switch to another mode with the retention period that you need
+
+To download and import the snapshot manually, download the appropriate snapshot for the network and mode (such as from http://snapshotter-sandbox.nomadic-labs.eu/) and import it with the `octez-evm-node snapshot import` command, as in this example:
 
 ```bash
 wget https://storage.googleapis.com/nl-sandboxes-etherlink--snapshots/etherlink-testnet/rolling/etherlink-testnet-rolling-latest.gz
@@ -127,6 +126,10 @@ octez-evm-node run observer \
   --data-dir <EVM_DATA_DIR>
 ```
 
+If you have configured the data directory and imported a snapshot, you can omit the `--history` argument from the `octez-evm-node run` command.
+Including this argument allows you to verify that the node is configured for the mode and retention period that you want to run the node in.
+The node throws an error if you try to run it in a mode that it is not configured for.
+
 To automatically download and import a snapshot, start the node with the `--init-from-snapshot` switch and the network and mode to use, as in this example:
 
 ```bash
@@ -141,13 +144,13 @@ The node can take time to download and import the snapshot.
 
 ### From an existing Etherlink Smart Rollup node
 
-1. Download [an Etherlink Smart Rollup node snapshot](https://snapshots.eu.tzinit.org/etherlink-ghostnet/), and use the `octez-smart-rollup-node` binary to import it in a temporary directory.
+1. Download [an Etherlink Smart Rollup node snapshot](https://snapshots.eu.tzinit.org), and use the `octez-smart-rollup-node` binary to import it in a temporary directory.
 The following examples use `<SR_OBSERVER_DATA_DIR>` as the location of this temporary directory.
 
    ```bash
-   wget https://snapshots.eu.tzinit.org/etherlink-mainnet/eth-mainnet.full
-   octez-smart-rollup-node --endpoint https://rpc.tzkt.io/mainnet \
-     snapshot import eth-mainnet.full \
+   wget https://snapshots.eu.tzinit.org/etherlink-ghostnet/eth-ghostnet.full
+   octez-smart-rollup-node --endpoint https://rpc.tzkt.io/ghostnet \
+     snapshot import eth-ghostnet.full \
      --data-dir <SR_OBSERVER_DATA_DIR>
    ```
 
@@ -180,6 +183,31 @@ The following examples use `<SR_OBSERVER_DATA_DIR>` as the location of this temp
    ```
 
    The `--initial-kernel` argument is needed only the first time that you start the node.
+
+## Switching history modes
+
+After the node is running in one mode you can switch to another history mode:
+
+1. Stop the node.
+1. Switch to the new mode with the command `octez-evm-node switch history to <MODE>`, where `<MODE>` is the new mode.
+1. Start the node as usual with the command `octez-evm-node run`.
+
+For example, you can switch to `rolling` mode with the command `octez-evm-node switch history to rolling:<DAYS>`, where `<DAYS>` is the number of days of compete data to keep.
+Then when you restart the node, run `octez-evm-node run observer --network testnet --history rolling:<DAYS> --data-dir <EVM_DATA_DIR>`.
+
+Because the node cannot reconstruct data that it does not have, you can switch from only some modes to some other modes:
+
+- The node can go from `archive` mode to `rolling` or `full` mode.
+- The node can go from `full` mode to `rolling` mode or `full` mode with a different retention period.
+- The node can go from `rolling` mode to `rolling` mode with a different retention period.
+
+When you switch from `full` or `rolling` mode and change the retention period, the node can increase the retention period, but it does not immediately retrieve the new data.
+For example, you can switch from `rolling:1` mode to `rolling:5` mode, but the node does not immediately download the previous 5 days of data.
+Instead, it begins storing more data as time passes until it has enough for 5 days of history.
+You can also start a node in `rolling:5` mode by downloading a rolling snapshot that is 5 days old or by switching from `archive` mode or `full` mode.
+
+Switching modes can increase the size of the data directory, so be sure that the node has enough disk space before switching.
+For example, switching from another mode to `rolling` mode requires more space than starting a node in `rolling` mode with the same retention period.
 
 ## Verifying that the node is running
 

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -137,6 +137,7 @@ octez-evm-node run observer \
   --network testnet \
   --history rolling:1 \
   --data-dir <EVM_DATA_DIR> \
+  --dont-track-rollup-node \
   --init-from-snapshot
 ```
 

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -23,7 +23,7 @@ The EVM node supports these history modes:
 
 - `archive` (the default): The node stores a copy of all available Etherlink information.
 
-- `full`: The node stores all of the necessary information to construct the current Etherlink state.
+- `full` (available starting with version 0.17): The node stores all of the necessary information to construct the current Etherlink state.
 
 - `rolling` (available starting with version 0.16): The node stores the current context plus the complete transaction data for a certain number of previous days.
 The default `rolling` mode stores the complete data for the previous 14 days.


### PR DESCRIPTION
EVM node 0.19 has:

- Rolling and full history modes
- Multiple options for importing snapshots