### PR TITLE
Consistent way to refer to variables based on Octez docs

### DIFF
--- a/docs/governance/how-do-i-participate-in-governance.mdx
+++ b/docs/governance/how-do-i-participate-in-governance.mdx
@@ -176,15 +176,15 @@ To propose a member for the Sequencer Committee, bakers can call the `new_propos
 ```bash
 octez-client transfer 0 from my_wallet to KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF \
   --entrypoint "new_proposal" \
-  --arg "Pair \"$PUBLIC_KEY\" $L2_ADDRESS"
+  --arg "Pair \"<PUBLIC_KEY>\" <L2_ADDRESS>"
 ```
 
 The command takes these parameters:
 
 - The address or Octez client alias of your baker account
 - The address of the Sequencer Committee governance contract
-- The public key (not the public key hash or account address) of the account to propose, including the double quotes
-- The Etherlink address of the account to propose; the examples below use `0xb7a970` as the account address
+- The public key (not the public key hash or account address) of the account to propose, including the double quotes, represented in this example as `<PUBLIC_KEY>`
+- The Etherlink address of the account to propose, represented in the previous example as `<L2_ADDRESS>`; the examples below use `0xb7a970` as the account address
 
 For example:
 

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -27,9 +27,11 @@ These images contain the correct version of the binary.
 
 ## Initializing the data directory
 
-1. If you want your EVM node to check the correctness of the blocks it receives via a Smart Rollup node, set the `sr_node_observer_rpc` environment variable to the URL of that Etherlink Smart Rollup node, such as `http://localhost:8932`.
-1. Set the `evm_observer_dir` environment variable to the directory where the node should store its local data.
-The default is `$HOME/.octez-evm-node`.
+1. If you want your EVM node to check the correctness of the blocks it receives via a Smart Rollup node, get the RPC URL of that Etherlink Smart Rollup node, such as `http://localhost:8932`.
+The following instructions use the variable `<SR_NODE_OBSERVER_RPC>` to represent this URL.
+1. Create a directory for the node to store its data in.
+The default directory is `$HOME/.octez-evm-node`.
+The following instructions use the variable `<EVM_DATA_DIR>` to represent this directory.
 1. Initialize the node by setting the data directory in the `--data-dir` argument and the network to use (such as `mainnet` or `testnet`) in the `--network` argument.
 
    To trust incoming blocks, use `--dont-track-rollup-node`:
@@ -37,17 +39,17 @@ The default is `$HOME/.octez-evm-node`.
    ```bash
    octez-evm-node init config \
      --network mainnet \
-     --data-dir $evm_observer_dir \
+     --data-dir <EVM_DATA_DIR> \
      --dont-track-rollup-node
    ```
 
-   Alternatively, if you want to rely on a Smart Rollup node to check the correctness of blocks coming from the sequencer, pass the `sr_node_observer_rpc` environment variable to the `--rollup-node-endpoint` argument:
+   Alternatively, if you want to rely on a Smart Rollup node to check the correctness of blocks coming from the sequencer, pass the address of the Smart Rollup node to the `--rollup-node-endpoint` argument, as in this example:
 
    ```bash
    octez-evm-node init config \
      --network mainnet \
-     --data-dir $evm_observer_dir \
-     --rollup-node-endpoint $sr_node_observer_rpc
+     --data-dir <EVM_DATA_DIR> \
+     --rollup-node-endpoint <SR_NODE_OBSERVER_RPC>
    ```
 
    The `--network` argument sets the node to use preimages that the Tezos Foundation hosts on a file server on a so-called "preimages endpoint".
@@ -72,7 +74,7 @@ To automatically download and import a snapshot, start the node with the `--init
 
 ```bash
 octez-evm-node run observer \
-  --data-dir $evm_observer_dir \
+  --data-dir <EVM_DATA_DIR> \
   --network testnet \
   --init-from-snapshot
 ```
@@ -84,7 +86,7 @@ To import the snapshot manually, download the snapshot from http://snapshotter-s
 ```bash
 wget http://snapshotter-sandbox.nomadic-labs.eu/etherlink-mainnet/evm-snapshot-sr1Ghq66tYK9y-latest.gz # this is for the latest mainnet etherlink snapshots, similarly there is one for testnet
 octez-evm-node snapshot import evm-snapshot-sr1Ghq66tYK9y-latest.gz \
-  --data-dir $evm_observer_dir
+  --data-dir <EVM_DATA_DIR>
 ```
 
 You can also pass the URL of the snapshot directly to the `octez-evm-node snapshot import` command.
@@ -94,36 +96,35 @@ Then, run this command to start the node, passing the data directory and the net
 ```bash
 octez-evm-node run observer \
   --network testnet \
-  --data-dir $evm_observer_dir
+  --data-dir <EVM_DATA_DIR>
 ```
 
 ### From an existing Etherlink Smart Rollup node
 
 1. Download [an Etherlink Smart Rollup node snapshot](https://snapshots.eu.tzinit.org/etherlink-ghostnet/), and use the `octez-smart-rollup-node` binary to import it in a temporary directory.
+The following examples use `<SR_OBSERVER_DATA_DIR>` as the location of this temporary directory.
 
    ```bash
    wget https://snapshots.eu.tzinit.org/etherlink-mainnet/eth-mainnet.full
    octez-smart-rollup-node --endpoint https://rpc.tzkt.io/mainnet \
      snapshot import eth-mainnet.full \
-     --data-dir $sr_observer_data_dir
+     --data-dir <SR_OBSERVER_DATA_DIR>
    ```
 
    :::tip
    If you are running a Smart Rollup node on the same machine, you can skip this step because you can reuse its data directory.
    :::
 
-1. Set the `sr_observer_data_dir` environment variable to the location of the data directory you got from the previous step.
-
 1. Run this command to import the kernel from the Smart Rollup node:
 
    ```bash
-   octez-evm-node init from rollup node $sr_observer_data_dir --data-dir $evm_observer_dir
+   octez-evm-node init from rollup node <SR_OBSERVER_DATA_DIR> --data-dir <EVM_DATA_DIR>
    ```
 
 1. Run this command to start the node:
 
    ```bash
-   octez-evm-node run observer --data-dir $evm_observer_dir
+   octez-evm-node run observer --data-dir <EVM_DATA_DIR>
    ```
 
    The EVM node runs in archive mode.
@@ -134,7 +135,7 @@ octez-evm-node run observer \
 1. Run this command to start the node with the Etherlink installer kernel that you built or downloaded; change the name of the `installer.hex` file in the command accordingly:
 
    ```bash
-   octez-evm-node run observer --data-dir $evm_observer_dir --initial-kernel installer.hex
+   octez-evm-node run observer --data-dir <EVM_DATA_DIR> --initial-kernel installer.hex
    ```
 
    The `--initial-kernel` argument is needed only the first time that you start the node.

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -53,8 +53,9 @@ The best place to get the most recent binary files to use with Etherlink is http
 
 1. Initialize the local context of the node, which is where it stores local data:
 
-   1. Set the environment variable `SR_DATA_DIR` to the directory where the node should store its local data.
-   The default value is `$HOME/.tezos-smart-rollup-node`.
+   1. Create a directory for the node to store its data in.
+   The default directory is `$HOME/.tezos-smart-rollup-node`.
+   The following instructions use the variable `<SR_DATA_DIR>` to represent this directory.
 
    1. Initialize the local context by running this command and passing the address of the Etherlink Smart Rollup and the preimages endpoint.
    You can get this information on the [Network information](/get-started/network-information) page.
@@ -63,7 +64,7 @@ The best place to get the most recent binary files to use with Etherlink is http
 
       ```bash
       octez-smart-rollup-node init observer config for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
-        with operators --data-dir $SR_DATA_DIR \
+        with operators --data-dir <SR_DATA_DIR> \
         --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
       ```
 
@@ -71,7 +72,7 @@ The best place to get the most recent binary files to use with Etherlink is http
 
       ```bash
       octez-smart-rollup-node init observer config for sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg \
-        with operators --data-dir $SR_DATA_DIR \
+        with operators --data-dir <SR_DATA_DIR> \
         --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-ghostnet/wasm_2_0_0
       ```
 
@@ -105,14 +106,14 @@ The best place to get the most recent binary files to use with Etherlink is http
       ```bash
       octez-smart-rollup-node --endpoint https://rpc.tzkt.io/mainnet \
         snapshot import eth-mainnet.full \
-        --data-dir $SR_DATA_DIR
+        --data-dir <SR_DATA_DIR>
       ```
 
 1. Start the Smart Rollup node in observer mode with the `run` command:
 
    ```bash
    octez-smart-rollup-node --endpoint https://rpc.tzkt.io/mainnet run \
-     --data-dir $SR_DATA_DIR
+     --data-dir <SR_DATA_DIR>
    ```
 
    If you did not load a snapshot, the process of starting the node from genesis can take a long time because it must process every block.
@@ -173,8 +174,10 @@ Converting the observer node to maintenance mode requires these prerequisites:
    - An account with at least 10,000 liquid, available tez, referred to as the _operator account_.
    You can use the same account that you use for a layer 1 baker, but for better security, you can use a different account and delegate its tez to the layer 1 account.
    Without 10,000 liquid tez, the Smart Rollup node will not start in operator or maintenance mode.
+   The following examples use the variable `<REMOTE_OPERATOR>` to represent this account.
 
    - An account with a small amount of liquid tez for cementing and outbox operations.
+   The following examples use the variable `<SECONDARY_ACCOUNT>` to represent this account.
 
    In most cases, you set these accounts up on another machine and use the Octez remote signer (`octez-signer`) to allow the Smart Rollup node to use them remotely.
    You can use a Ledger device to secure the keys.
@@ -188,13 +191,13 @@ Follow these steps to convert a Smart Rollup node from observer mode to maintena
 1. If you are using a remote signer, set up the two accounts in the remote signer:
 
    1. Create the two accounts in the `octez-signer` program or import them from a Ledger device.
-   For example, to create accounts, run this command:
+   For example, to create accounts, run this command, where `<REMOTE_OPERATOR>` is the alias for the account:
 
       ```bash
-      octez-signer gen keys REMOTE_OPERATOR
+      octez-signer gen keys <REMOTE_OPERATOR>
       ```
 
-      To import accounts from a Ledger device, get the address of the connected device by running the command `octez-signer list connected ledgers` and then import the key from the ledger by running the command `octez-signer import secret key REMOTE_OPERATOR ledger://XXXXXXXXXX`, where `ledger://XXXXXXXXXX` is the address of the connected device.
+      To import accounts from a Ledger device, get the address of the connected device by running the command `octez-signer list connected ledgers` and then import the key from the ledger by running the command `octez-signer import secret key <REMOTE_OPERATOR> ledger://XXXXXXXXXX`, where `ledger://XXXXXXXXXX` is the address of the connected device.
 
    1. Configure the remote signer to allow other Octez programs to sign with those accounts.
    For example, this command makes the keys available over the TCP protocol on localhost:
@@ -230,7 +233,7 @@ Follow these steps to convert a Smart Rollup node from observer mode to maintena
    For example:
 
    ```bash
-   octez-client import secret key REMOTE_OPERATOR tcp://localhost:7732/tz1QCVQinE8iVj1H2fckqx6oiM85CNJSK9Sx
+   octez-client import secret key <REMOTE_OPERATOR> tcp://localhost:7732/tz1QCVQinE8iVj1H2fckqx6oiM85CNJSK9Sx
    ```
 
    If you are not using a remote signer, you can use the `octez-client gen keys` or `octez-client import secret key` commands to create or import keys as usual.
@@ -238,7 +241,7 @@ Follow these steps to convert a Smart Rollup node from observer mode to maintena
 1. Verify that the machine that is running the Smart Rollup node can use the keys by signing a message with them, as in this example:
 
    ```bash
-   octez-client sign bytes 0x03 for REMOTE_OPERATOR
+   octez-client sign bytes 0x03 for <REMOTE_OPERATOR>
    ```
 
    If the client is successful, it returns `Signature:` and the signed message.
@@ -247,11 +250,11 @@ Follow these steps to convert a Smart Rollup node from observer mode to maintena
 
 1. Stop the Smart Rollup node.
 
-1. Restart the node with the layer 1 node that you control, represented in this example by the variable `$MY_LAYER_1_NODE`:
+1. Restart the node with the layer 1 node that you control, represented in this example by the variable `<MY_LAYER_1_NODE>`:
 
    ```bash
-   octez-smart-rollup-node --endpoint $MY_LAYER_1_NODE run \
-     --data-dir $SR_DATA_DIR
+   octez-smart-rollup-node --endpoint <MY_LAYER_1_NODE> run \
+     --data-dir <SR_DATA_DIR>
    ```
 
 1. Verify that the node continues to run as expected in observer mode.
@@ -262,17 +265,17 @@ Follow these steps to convert a Smart Rollup node from observer mode to maintena
 
    The first address after `with operators` is the default address that the node uses for operations.
    You can use different accounts for specific operations by adding the operation and the address to the command.
-   This example uses `$REMOTE_OPERATOR` for the account with 10,000 liquid tez and `$SECONDARY_ACCOUNT` for cementing operations and executing outbox operations:
+   This example uses `<REMOTE_OPERATOR>` for the account with 10,000 liquid tez and `<SECONDARY_ACCOUNT>` for cementing operations and executing outbox operations:
 
    ```bash
    octez-smart-rollup-node \
-     --endpoint $MY_LAYER_1_NODE \
+     --endpoint <MY_LAYER_1_NODE> \
      run maintenance for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
-     with operators $REMOTE_OPERATOR \
-     cementing:$SECONDARY_ACCOUNT \
-     executing_outbox:$SECONDARY_ACCOUNT \
+     with operators <REMOTE_OPERATOR> \
+     cementing:<SECONDARY_ACCOUNT> \
+     executing_outbox:<SECONDARY_ACCOUNT> \
      --rpc-addr 0.0.0.0 \
-     --data-dir $SR_DATA_DIR \
+     --data-dir <SR_DATA_DIR> \
      --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
    ```
 
@@ -307,9 +310,9 @@ A node running in `bailout` mode defends its existing commitments but does not m
    ```bash
    octez-smart-rollup-node --endpoint <MY_LAYER_1_NODE> \
      run bailout for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
-     with operators $REMOTE_OPERATOR \
+     with operators <REMOTE_OPERATOR> \
      --rpc-addr 0.0.0.0 \
-     --data-dir $SR_DATA_DIR \
+     --data-dir <SR_DATA_DIR> \
      --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
    ```
 
@@ -322,11 +325,11 @@ Now the node has stopped and the bonded tez is liquid.
 If you want to recover the bond manually, use this command:
 
 ```bash
-octez-client recover bond of $BONDED_ACCOUNT for smart rollup $SMART_ROLLUP_ADDRESS from $MY_ACCOUNT
+octez-client recover bond of <BONDED_ACCOUNT> for smart rollup <SMART_ROLLUP_ADDRESS> from <MY_ACCOUNT>
 ```
 
 This command uses these arguments:
 
-- `BONDED_ACCOUNT`: The account that you used to run the Smart Rollup in operator mode
-- `SMART_ROLLUP_ADDRESS`: The address of the Etherlink Smart Rollup
-- `MY_ACCOUNT`: The account to use to send this `recover bond` operation
+- `<BONDED_ACCOUNT>`: The account that you used to run the Smart Rollup in operator mode
+- `<SMART_ROLLUP_ADDRESS>`: The address of the Etherlink Smart Rollup
+- `<MY_ACCOUNT>`: The account to use to send this `recover bond` operation


### PR DESCRIPTION
Octez docs use variables like `<VARIABLE_NAME>`, so this PR makes consistent how we refer to variables.