### PR TITLE
Use only web3 wallets

### DIFF
--- a/src/components/WalletConnectButton/index.jsx
+++ b/src/components/WalletConnectButton/index.jsx
@@ -46,20 +46,6 @@ const mainnet = defineChain({
 });
 
 const wallets = [
-  inAppWallet({
-    auth: {
-      options: [
-        "google",
-        "discord",
-        "telegram",
-        "farcaster",
-        "email",
-        "x",
-        "passkey",
-        "phone",
-      ],
-    },
-  }),
   createWallet("io.metamask"),
   createWallet("com.coinbase.wallet"),
   createWallet("me.rainbow"),


### PR DESCRIPTION
Hide other options of connecting to Etherlink and allow only web3 wallets.

Before: 
![Screenshot 2025-02-11 at 12 33 19 PM](https://github.com/user-attachments/assets/c8d11e7f-e160-47c0-bdf0-506ec12fc5d9)


After:

![Screenshot 2025-02-11 at 12 33 35 PM](https://github.com/user-attachments/assets/737b3aa9-83f0-44f0-8830-ffd9add9699a)
