### PR TITLE
Updates to governance contracts and periods for Calypso

### DIFF
--- a/docs/governance/how-do-i-participate-in-governance.mdx
+++ b/docs/governance/how-do-i-participate-in-governance.mdx
@@ -32,17 +32,17 @@ You need the address of the correct governance contract to propose changes and v
 </tr>
 <tr>
 <td>Kernel governance</td>
-<td><InlineCopy code="KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J" href="https://better-call.dev/mainnet/KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J" abbreviate="6,4"></InlineCopy></td>
+<td><InlineCopy code="KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK" href="https://better-call.dev/mainnet/KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK" abbreviate="6,4"></InlineCopy></td>
 <td><InlineCopy code="KT1HfJb718fGszcgYguA4bfTjAqe1BEmFHkv" href="https://better-call.dev/ghostnet/KT1HfJb718fGszcgYguA4bfTjAqe1BEmFHkv" abbreviate="6,4"></InlineCopy></td>
 </tr>
 <tr>
 <td>Kernel security governance</td>
-<td><InlineCopy code="KT1N5MHQW5fkqXkW9GPjRYfn5KwbuYrvsY1g" href="https://better-call.dev/mainnet/KT1N5MHQW5fkqXkW9GPjRYfn5KwbuYrvsY1g" abbreviate="6,4"></InlineCopy></td>
+<td><InlineCopy code="KT1GRAN26ni19mgd6xpL6tsH52LNnhKSQzP2" href="https://better-call.dev/mainnet/KT1GRAN26ni19mgd6xpL6tsH52LNnhKSQzP2" abbreviate="6,4"></InlineCopy></td>
 <td><InlineCopy code="KT1QDgF5pBkXEizj5RnmagEyxLxMTwVRpmYk" href="https://better-call.dev/ghostnet/KT1QDgF5pBkXEizj5RnmagEyxLxMTwVRpmYk" abbreviate="6,4"></InlineCopy></td>
 </tr>
 <tr>
 <td>Sequencer committee</td>
-<td><InlineCopy code="KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF" href="https://better-call.dev/mainnet/KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF" abbreviate="6,4"></InlineCopy></td>
+<td><InlineCopy code="KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U" href="https://better-call.dev/mainnet/KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U" abbreviate="6,4"></InlineCopy></td>
 <td><InlineCopy code="KT1FRzozuzFMWLimpFeSdADHTMxzU8KtgCr9" href="https://better-call.dev/ghostnet/KT1FRzozuzFMWLimpFeSdADHTMxzU8KtgCr9" abbreviate="6,4"></InlineCopy></td>
 </tr>
 </tbody>
@@ -62,7 +62,7 @@ For example, this Octez client command calls this view for the kernel governance
 
 ```bash
 octez-client -E https://mainnet.ecadinfra.com \
-  run view get_voting_state on contract KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J
+  run view get_voting_state on contract KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK
 ```
 
 The view returns information about the current governance period in this order:
@@ -87,7 +87,7 @@ You can also subscribe to the `voting_finished` event to be notified when the Pr
 During a Proposal period, bakers can propose kernel or security updates by calling the `new_proposal` entrypoint of the appropriate governance contract and passing the hash of their proposed kernel, as in this example, which uses `0x00927d...` as an example kernel hash:
 
 ```bash
-octez-client transfer 0 from my_wallet to KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J \
+octez-client transfer 0 from my_wallet to KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK \
   --entrypoint "new_proposal" \
   --arg "0x009279df4982e47cf101e2525b605fa06cd3ccc0f67d1c792a6a3ea56af9606abc"
 ```
@@ -105,7 +105,7 @@ To upvote a proposed kernel or security update during a Proposal period, call th
 This example again uses `0x00927d...` as an example kernel hash:
 
 ```bash
-octez-client transfer 0 from my_wallet to KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J \
+octez-client transfer 0 from my_wallet to KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK \
   --entrypoint "upvote_proposal" \
   --arg "0x009279df4982e47cf101e2525b605fa06cd3ccc0f67d1c792a6a3ea56af9606abc"
 ```
@@ -117,7 +117,7 @@ It's not necessary to upvote a proposal that you submitted; submitting a proposa
 When a proposal is in the Promotion period, you can vote for or against it or pass on voting by calling the `vote` entrypoint of the appropriate governance contract:
 
 ```bash
-octez-client transfer 0 from my_wallet to KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J \
+octez-client transfer 0 from my_wallet to KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK \
   --entrypoint "vote" --arg '"yea"'
 ```
 
@@ -134,7 +134,7 @@ The command does not need the hash of the kernel because only one kernel can be 
 After a proposal wins a vote, any user can trigger the kernel or security upgrade by calling the governance contract's `trigger_kernel_upgrade` entrypoint:
 
 ```bash
-octez-client transfer 0 from my_wallet to KT1N5MHQW5fkqXkW9GPjRYfn5KwbuYrvsY1g \
+octez-client transfer 0 from my_wallet to KT1GRAN26ni19mgd6xpL6tsH52LNnhKSQzP2 \
   --entrypoint "trigger_kernel_upgrade" \
   --arg '"sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf"'
 ```
@@ -161,7 +161,7 @@ To get information about the current state of the Sequencer Committee governance
 For example, this Octez client command calls this view for the kernel governance contract on Mainnet:
 
 ```bash
-octez-client run view get_voting_state on contract KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF
+octez-client run view get_voting_state on contract KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U
 ```
 
 The view returns information about the current governance period.
@@ -174,7 +174,7 @@ You can also subscribe to the `voting_finished` event to be notified when the Pr
 To propose a member for the Sequencer Committee, bakers can call the `new_proposal` entrypoint of the governance contract during the Proposal period:
 
 ```bash
-octez-client transfer 0 from my_wallet to KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF \
+octez-client transfer 0 from my_wallet to KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U \
   --entrypoint "new_proposal" \
   --arg "Pair \"<PUBLIC_KEY>\" <L2_ADDRESS>"
 ```
@@ -189,7 +189,7 @@ The command takes these parameters:
 For example:
 
 ```bash
-octez-client transfer 0 from my_wallet to KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF \
+octez-client transfer 0 from my_wallet to KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U \
   --entrypoint "new_proposal" \
   --arg 'Pair "edpkurcgafZ2URyB6zsm5d1YqmLt9r1Lk89J81N6KpyMaUzXWEsv1X" 0xb7a97043983f24991398e5a82f63f4c58a417185'
 ```
@@ -197,7 +197,7 @@ octez-client transfer 0 from my_wallet to KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF \
 To upvote a proposed committee member during a Proposal period, call the `upvote_proposal` entrypoint with the same parameters:
 
 ```bash
-octez-client transfer 0 from my_wallet to KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF \
+octez-client transfer 0 from my_wallet to KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U \
   --entrypoint "upvote_proposal" \
   --arg 'Pair "edpkurcgafZ2URyB6zsm5d1YqmLt9r1Lk89J81N6KpyMaUzXWEsv1X" 0xb7a97043983f24991398e5a82f63f4c58a417185'
 ```
@@ -209,7 +209,7 @@ It's not necessary to upvote a proposal that you submitted; submitting a proposa
 When a proposal is in the Promotion period, you can vote for or against it or pass on voting by calling the `vote` entrypoint of the governance contract:
 
 ```bash
-octez-client transfer 0 from my_wallet to KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J \
+octez-client transfer 0 from my_wallet to KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK \
   --entrypoint "vote" --arg '"yea"'
 ```
 
@@ -231,7 +231,7 @@ octez-client transfer 0 from tz1RLPEeMxbJYQBFbXYw8WHdXjeUjnG5ZXNq to KT1FRzozuzF
 After a proposed member wins a vote, any user can trigger the change to the committee by calling the governance contract's `trigger_committee_upgrade` entrypoint:
 
 ```bash
-octez-client transfer 0 from my_wallet to KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J \
+octez-client transfer 0 from my_wallet to KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK \
   --entrypoint "trigger_committee_upgrade" \
   --arg '"sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf"'
 ```

--- a/docs/governance/how-is-etherlink-governed.md
+++ b/docs/governance/how-is-etherlink-governed.md
@@ -21,12 +21,12 @@ The Etherlink kernel governance process is a streamlined version of the [Tezos g
 It consists of three periods: a Proposal period and a Promotion period, which are supervised by Etherlink's kernel governance contract, and a Cooldown period, which is enforced by the Etherlink kernel itself.
 
 The lengths of these periods are stored in the [kernel governance contract](https://better-call.dev/mainnet/KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK).
-This table shows the period lengths as of the Bifröst Etherlink update and the Tezos Quebec protocol:
+This table shows the period lengths as of the Calypso Etherlink update and the Tezos Quebec protocol:
 
 Period | Length | Approximate time
 --- | --- | ---
-Proposal | 20480 layer 1 blocks | About 2 days
-Promotion | 20480 layer 1 blocks | About 2 days
+Proposal | 30720 layer 1 blocks | About 3 days
+Promotion | 30720 layer 1 blocks | About 3 days
 Cooldown | 86400 seconds | About 1 day
 
 Note that these periods can vary.
@@ -40,7 +40,7 @@ Any baker can submit kernel upgrade proposals and upvote proposals, with the wei
 Bakers can submit and upvote up to 20 proposals in a single Proposal period.
 
 At the end of the period, if a proposal has enough voting power to meet a certain percentage of the total voting power, it moves to the next phase.
-As of the Bifröst update, the leading proposal must gather support from at least 1% of the total voting power to move to the next phase.
+As of the Calypso update, the leading proposal must gather support from at least 1% of the total voting power to move to the next phase.
 If no proposal gathers adequate support, a new Proposal period begins.
 
 ### 2. Promotion period
@@ -54,7 +54,7 @@ To pass, the proposal must meet both of these requirements:
 - Supermajority: The total voting power of the Yea votes must reach a supermajority.
 
 The thresholds for these requirements are stored in the governance contract.
-This table shows the requirements as of the Bifröst Etherlink update:
+This table shows the requirements as of the Calypso Etherlink update:
 
 Requirement | Threshold
 --- | ---
@@ -94,12 +94,12 @@ The security governance process is like the kernel governance process, with thes
 
 The security governance process has the same Proposal, Promotion, and Cooldown periods as the kernel governance process, but the lengths of these periods are different.
 The lengths are stored in the [security governance contract](https://better-call.dev/mainnet/KT1GRAN26ni19mgd6xpL6tsH52LNnhKSQzP2).
-This table shows the period lengths as of the Bifröst Etherlink update and the Tezos Quebec protocol:
+This table shows the period lengths as of the Calypso Etherlink update and the Tezos Quebec protocol:
 
 Period | Length | Approximate time
 --- | --- | ---
-Proposal | 2560 layer 1 blocks | About 5.5 hours
-Promotion | 2560 layer 1 blocks | About 5.5 hours
+Proposal | 3200 layer 1 blocks | About 7 hours
+Promotion | 3200 layer 1 blocks | About 7 hours
 Cooldown | 86400 seconds | About 1 day
 
 Like the kernel governance periods, these periods can vary based on the timing of layer 1 blocks and when users activate the new kernel at the end of the Cooldown period.
@@ -109,7 +109,7 @@ Like the kernel governance periods, these periods can vary based on the timing o
 The differences in thresholds in the security governance process ensure expedited resolution of urgent issues while upholding integrity by demanding higher quorum to prevent potential nefarious actions.
 
 The thresholds for the quorum and supermajority requirements are stored in the governance contract.
-This table shows the requirements as of the Bifröst Etherlink update:
+This table shows the requirements as of the Calypso Etherlink update:
 
 Period | Requirement | Threshold
 --- | --- | ---
@@ -127,18 +127,18 @@ Similar to the kernel and security governance processes, the Sequencer Committee
 In this process, bakers propose and vote on members for the Sequencer Committee.
 
 The lengths of the periods are stored in the [sequencer committee governance contract](https://better-call.dev/mainnet/KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U).
-This table shows the period lengths as of the Bifröst Etherlink update and the Tezos Quebec protocol:
+This table shows the period lengths as of the Calypso Etherlink update and the Tezos Quebec protocol:
 
 Period | Length | Approximate time
 --- | --- | ---
-Proposal | 40960 layer 1 blocks | About 4 days
-Promotion | 40960 layer 1 blocks | About 4 days
+Proposal | 51200 layer 1 blocks | About 5 days
+Promotion | 51200 layer 1 blocks | About 5 days
 Cooldown | 86400 seconds | About 1 day
 
 ### Thresholds
 
 The thresholds for the quorum and supermajority requirements are stored in the governance contract.
-This table shows the requirements as of the Bifröst Etherlink update:
+This table shows the requirements as of the Calypso Etherlink update:
 
 Period | Requirement | Threshold
 --- | --- | ---

--- a/docs/governance/how-is-etherlink-governed.md
+++ b/docs/governance/how-is-etherlink-governed.md
@@ -20,7 +20,7 @@ For the addresses of the contracts that manage governance, see [How do I partici
 The Etherlink kernel governance process is a streamlined version of the [Tezos governance and self-amendment process](https://docs.tezos.com/architecture/governance).
 It consists of three periods: a Proposal period and a Promotion period, which are supervised by Etherlink's kernel governance contract, and a Cooldown period, which is enforced by the Etherlink kernel itself.
 
-The lengths of these periods are stored in the [kernel governance contract](https://better-call.dev/mainnet/KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J).
+The lengths of these periods are stored in the [kernel governance contract](https://better-call.dev/mainnet/KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK).
 This table shows the period lengths as of the Bifröst Etherlink update and the Tezos Quebec protocol:
 
 Period | Length | Approximate time
@@ -93,7 +93,7 @@ The security governance process is like the kernel governance process, with thes
 ### Periods
 
 The security governance process has the same Proposal, Promotion, and Cooldown periods as the kernel governance process, but the lengths of these periods are different.
-The lengths are stored in the [security governance contract](https://better-call.dev/mainnet/KT1N5MHQW5fkqXkW9GPjRYfn5KwbuYrvsY1g).
+The lengths are stored in the [security governance contract](https://better-call.dev/mainnet/KT1GRAN26ni19mgd6xpL6tsH52LNnhKSQzP2).
 This table shows the period lengths as of the Bifröst Etherlink update and the Tezos Quebec protocol:
 
 Period | Length | Approximate time
@@ -126,7 +126,7 @@ A separate sequencer governance contract handles the selection process for Ether
 Similar to the kernel and security governance processes, the Sequencer Committee voting process has Proposal, Promotion, and Cooldown periods.
 In this process, bakers propose and vote on members for the Sequencer Committee.
 
-The lengths of the periods are stored in the [sequencer committee governance contract](https://better-call.dev/mainnet/KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF).
+The lengths of the periods are stored in the [sequencer committee governance contract](https://better-call.dev/mainnet/KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U).
 This table shows the period lengths as of the Bifröst Etherlink update and the Tezos Quebec protocol:
 
 Period | Length | Approximate time


### PR DESCRIPTION
Governance contracts are changing with the Calypso upgrade to keep up with block time changes on layer 1. Testnet governance contracts will stay the same.

Here's my governance period math:

- Kernel governance: 30720 blocks * 8 sec/block / 60 secs/minute / 60 minutes/hour / 24 hours/day = 2.84 days, round up to 3 days
- Security governance: 3200 blocks * 8 sec/block / 60 secs/minute / 60 minutes/hour = 7.1 hours, round down to 7 hours
- Sequencer committee: 51200 blocks * 8sec/block / 60 secs/minute / 60 minutes/hour / 24 hours/day = 4.74 days, round up to 5 days

**IMPORTANT**

These contracts are for voting AFTER the Calypso upgrade (if it is approved and deployed). Do NOT use these contracts to vote on including the Calpyso upgrade.