### PR TITLE
Abbreviate addresses automatically

### DIFF
--- a/docs/bridging/bridging-evm.mdx
+++ b/docs/bridging/bridging-evm.mdx
@@ -130,43 +130,43 @@ This table shows the Etherlink address of tokens that you can bridge between Eth
     <tr>
       <td>USDC</td>
       <td>USD Coin</td>
-      <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
+      <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" abbreviate="5,4"></InlineCopy></td>
     </tr>
 
     <tr>
       <td>USDT</td>
       <td>Tether USD</td>
-      <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A">0x2C0...fE6a</InlineCopy></td>
+      <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" abbreviate="5,4"></InlineCopy></td>
     </tr>
 
     <tr>
       <td>WBTC</td>
       <td>Wrapped BTC</td>
-      <td><InlineCopy href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...sd0F</InlineCopy></td>
+      <td><InlineCopy href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" abbreviate="5,4"></InlineCopy></td>
     </tr>
 
     <tr>
       <td>WETH</td>
       <td>Wrapped Ether</td>
-      <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
+      <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401" abbreviate="5,4"></InlineCopy></td>
     </tr>
 
     <tr>
       <td>WBNB</td>
       <td>Wrapped BNB</td>
-      <td><InlineCopy href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" code="0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C">0xaA4...0d8C</InlineCopy></td>
+      <td><InlineCopy href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" code="0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" abbreviate="5,4"></InlineCopy></td>
     </tr>
 
     <tr>
       <td>WAVAX</td>
       <td>Wrapped AVAX</td>
-      <td><InlineCopy href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" code="0xe820995cD39B6E09EAa7e4e16337184b4A61B644">0xe82...B644</InlineCopy></td>
+      <td><InlineCopy href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" code="0xe820995cD39B6E09EAa7e4e16337184b4A61B644" abbreviate="5,4"></InlineCopy></td>
     </tr>
 
     <tr>
       <td>SHIB</td>
       <td>SHIBA INU</td>
-      <td><InlineCopy href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" code="0xBBD1F50A212357067318a84179892684e1Ac5181">0xBBD...5181</InlineCopy></td>
+      <td><InlineCopy href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" code="0xBBD1F50A212357067318a84179892684e1Ac5181" abbreviate="5,4"></InlineCopy></td>
     </tr>
   </tbody>
 </table>
@@ -189,27 +189,27 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tr>
   <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" code="0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48">0xA0b...eB48</InlineCopy></td>
+  <td><InlineCopy href="https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" code="0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy href="https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7" code="0xdAC17F958D2ee523a2206206994597C13D831ec7">0xdAC...1ec7</InlineCopy></td>
+  <td><InlineCopy href="https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7" code="0xdAC17F958D2ee523a2206206994597C13D831ec7" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>WBTC</td>
   <td>Wrapped BTC</td>
-  <td><InlineCopy href="https://etherscan.io/address/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" code="0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599">0x226...C599</InlineCopy></td>
+  <td><InlineCopy href="https://etherscan.io/address/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" code="0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy href="https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" code="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2">0xC02...6Cc2</InlineCopy></td>
+  <td><InlineCopy href="https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" code="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>SHIB</td>
   <td>SHIBA INU</td>
-  <td><InlineCopy href="https://etherscan.io/address/0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" code="0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE">0x95a...C4cE</InlineCopy></td>
+  <td><InlineCopy href="https://etherscan.io/address/0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" code="0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE" abbreviate="5,4"></InlineCopy></td>
 </tr>
 
 </tbody>
@@ -230,22 +230,22 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tr>
   <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831" code="0xaf88d065e77c8cC2239327C5EDb3A432268e5831">0xaf8...5831</InlineCopy></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831" code="0xaf88d065e77c8cC2239327C5EDb3A432268e5831" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy href="https://arbiscan.io/address/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" code="0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9">0xFd0...Cbb9</InlineCopy></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" code="0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>WBTC</td>
   <td>Wrapped BTC</td>
-  <td><InlineCopy href="https://arbiscan.io/address/0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" code="0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f">0x2f2...5B0f</InlineCopy></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" code="0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy href="https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" code="0x82aF49447D8a07e3bd95BD0d56f35241523fBab1">0x82a...Bab1</InlineCopy></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" code="0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" abbreviate="5,4"></InlineCopy></td>
 </tr>
 
 </tbody>
@@ -266,12 +266,12 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tr>
   <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" code="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913">0x833...2913</InlineCopy></td>
+  <td><InlineCopy href="https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" code="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy href="https://basescan.org/address/0x4200000000000000000000000000000000000006" code="0x4200000000000000000000000000000000000006">0x420...0006</InlineCopy></td>
+  <td><InlineCopy href="https://basescan.org/address/0x4200000000000000000000000000000000000006" code="0x4200000000000000000000000000000000000006" abbreviate="5,4"></InlineCopy></td>
 </tr>
 
 </tbody>
@@ -292,17 +292,17 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tr>
   <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" code="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85">0x0b2...Ff85</InlineCopy></td>
+  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" code="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"></InlineCopy></td>
 </tr>
 <tr>
   <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" code="0x94b008aA00579c1307B0EF2c499aD98a8ce58e58">0x94b...8e58</InlineCopy></td>
+  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" code="0x94b008aA00579c1307B0EF2c499aD98a8ce58e58"></InlineCopy></td>
 </tr>
 <tr>
   <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000006" code="0x4200000000000000000000000000000000000006">0x420...0006</InlineCopy></td>
+  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000006" code="0x4200000000000000000000000000000000000006"></InlineCopy></td>
 </tr>
 
 </tbody>
@@ -323,17 +323,17 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tr>
   <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://bscscan.com/address/0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d" code="0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d">0x8ac...580d</InlineCopy></td>
+  <td><InlineCopy href="https://bscscan.com/address/0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d" code="0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy href="https://bscscan.com/address/0x55d398326f99059ff775485246999027b3197955" code="0x55d398326f99059ff775485246999027b3197955">0x55d...7955</InlineCopy></td>
+  <td><InlineCopy href="https://bscscan.com/address/0x55d398326f99059ff775485246999027b3197955" code="0x55d398326f99059ff775485246999027b3197955" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>WBNB</td>
   <td>Wrapped BNB</td>
-  <td><InlineCopy href="https://bscscan.com/token/0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c" code="0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c">0xbb4...095c</InlineCopy></td>
+  <td><InlineCopy href="https://bscscan.com/token/0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c" code="0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c" abbreviate="5,4"></InlineCopy></td>
 </tr>
 
 </tbody>
@@ -354,17 +354,17 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tr>
   <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" code="0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E">0xB97...8a6E</InlineCopy></td>
+  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" code="0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" code="0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7">0x970...A8c7</InlineCopy></td>
+  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" code="0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>WAVAX</td>
   <td>Wrapped AVAX</td>
-  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7" code="0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7">B31f6...66c7</InlineCopy></td>
+  <td><InlineCopy href="https://avascan.info/blockchain/c/address/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7" code="0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7" abbreviate="5,4"></InlineCopy></td>
 </tr>
 
 </tbody>

--- a/docs/bridging/bridging-evm.mdx
+++ b/docs/bridging/bridging-evm.mdx
@@ -292,17 +292,17 @@ These tables show the addresses of the equivalent tokens on other networks:
 <tr>
   <td>USDC</td>
   <td>USD Coin</td>
-  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" code="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"></InlineCopy></td>
+  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" code="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>USDT</td>
   <td>Tether USD</td>
-  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" code="0x94b008aA00579c1307B0EF2c499aD98a8ce58e58"></InlineCopy></td>
+  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" code="0x94b008aA00579c1307B0EF2c499aD98a8ce58e58" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>WETH</td>
   <td>Wrapped Ether</td>
-  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000006" code="0x4200000000000000000000000000000000000006"></InlineCopy></td>
+  <td><InlineCopy href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000006" code="0x4200000000000000000000000000000000000006" abbreviate="5,4"></InlineCopy></td>
 </tr>
 
 </tbody>

--- a/docs/building-on-etherlink/tokens.mdx
+++ b/docs/building-on-etherlink/tokens.mdx
@@ -28,49 +28,49 @@ Click the address to go to the block explorer page for the token:
 <tr>
   <td>Wrapped XTZ (see <a href="#wxtz">WXTZ</a> below)</td>
   <td>WXTZ</td>
-  <td><InlineCopy code="0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb" href="https://explorer.etherlink.com/address/0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb">0xc9B...3EAb</InlineCopy></td>
-  <td><InlineCopy code="0xB1Ea698633d57705e93b0E40c1077d46CD6A51d8" href="https://testnet.explorer.etherlink.com/address/0xB1Ea698633d57705e93b0E40c1077d46CD6A51d8">0xB1E...51d8</InlineCopy></td>
+  <td><InlineCopy code="0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb" href="https://explorer.etherlink.com/address/0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb" abbreviate="5,4"></InlineCopy></td>
+  <td><InlineCopy code="0xB1Ea698633d57705e93b0E40c1077d46CD6A51d8" href="https://testnet.explorer.etherlink.com/address/0xB1Ea698633d57705e93b0E40c1077d46CD6A51d8" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>Tether USD</td>
   <td>USDT</td>
-  <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A">0x2C0...fE6a</InlineCopy></td>
-  <td><InlineCopy code="0xf7f007dc8Cb507e25e8b7dbDa600c07FdCF9A75B" href="https://testnet.explorer.etherlink.com/address/0xf7f007dc8Cb507e25e8b7dbDa600c07FdCF9A75B">0xf7f...A75B</InlineCopy></td>
+  <td><InlineCopy code="0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" href="https://explorer.etherlink.com/address/0x2C03058C8AFC06713be23e58D2febC8337dbfE6A" abbreviate="5,4"></InlineCopy></td>
+  <td><InlineCopy code="0xf7f007dc8Cb507e25e8b7dbDa600c07FdCF9A75B" href="https://testnet.explorer.etherlink.com/address/0xf7f007dc8Cb507e25e8b7dbDa600c07FdCF9A75B" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>USD Coin</td>
   <td>USDC</td>
-  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9">0x796...00F9</InlineCopy></td>
-  <td><InlineCopy code="0x4C2AA252BEe766D3399850569713b55178934849" href="https://testnet.explorer.etherlink.com/address/0x4C2AA252BEe766D3399850569713b55178934849">0x4C2...4849</InlineCopy></td>
+  <td><InlineCopy code="0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" href="https://explorer.etherlink.com/address/0x796Ea11Fa2dD751eD01b53C372fFDB4AAa8f00F9" abbreviate="5,4"></InlineCopy></td>
+  <td><InlineCopy code="0x4C2AA252BEe766D3399850569713b55178934849" href="https://testnet.explorer.etherlink.com/address/0x4C2AA252BEe766D3399850569713b55178934849" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>Wrapped Ether</td>
   <td>WETH</td>
-  <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401">0xfc2...B401</InlineCopy></td>
-  <td><InlineCopy code="0x86932ff467A7e055d679F7578A0A4F96Be287861" href="https://testnet.explorer.etherlink.com/address/0x86932ff467A7e055d679F7578A0A4F96Be287861">0x869...7861</InlineCopy></td>
+  <td><InlineCopy code="0xfc24f770F94edBca6D6f885E12d4317320BcB401" href="https://explorer.etherlink.com/address/0xfc24f770F94edBca6D6f885E12d4317320BcB401" abbreviate="5,4"></InlineCopy></td>
+  <td><InlineCopy code="0x86932ff467A7e055d679F7578A0A4F96Be287861" href="https://testnet.explorer.etherlink.com/address/0x86932ff467A7e055d679F7578A0A4F96Be287861" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>Wrapped BTC</td>
   <td>WBTC</td>
-  <td><InlineCopy code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F">0xbFc...3d0F</InlineCopy></td>
+  <td><InlineCopy code="0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" href="https://explorer.etherlink.com/address/0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F" abbreviate="5,4"></InlineCopy></td>
   <td></td>
 </tr>
 <tr>
   <td>Wrapped BNB</td>
   <td>WBNB</td>
-  <td><InlineCopy code="0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C">0xaA4...0d8C</InlineCopy></td>
+  <td><InlineCopy code="0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" href="https://explorer.etherlink.com/address/0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C" abbreviate="5,4"></InlineCopy></td>
   <td></td>
 </tr>
 <tr>
   <td>Wrapped AVAX</td>
   <td>WAVAX</td>
-  <td><InlineCopy code="0xe820995cD39B6E09EAa7e4e16337184b4A61B644" href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644">0xe82...B644</InlineCopy></td>
+  <td><InlineCopy code="0xe820995cD39B6E09EAa7e4e16337184b4A61B644" href="https://explorer.etherlink.com/address/0xe820995cD39B6E09EAa7e4e16337184b4A61B644" abbreviate="5,4"></InlineCopy></td>
   <td></td>
 </tr>
 <tr>
   <td>SHIBA INU</td>
   <td>SHIB</td>
-  <td><InlineCopy code="0xBBD1F50A212357067318a84179892684e1Ac5181" href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181">0xBBD...5181</InlineCopy></td>
+  <td><InlineCopy code="0xBBD1F50A212357067318a84179892684e1Ac5181" href="https://explorer.etherlink.com/address/0xBBD1F50A212357067318a84179892684e1Ac5181" abbreviate="5,4"></InlineCopy></td>
   <td></td>
 </tr>
 </tbody>
@@ -114,23 +114,23 @@ Here are the chains the token is deployed on:
 <tbody>
 <tr>
   <td>Etherlink</td>
-  <td><InlineCopy code="0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb" href="https://explorer.etherlink.com/address/0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb">0xc9B...3EAb</InlineCopy></td>
+  <td><InlineCopy code="0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb" href="https://explorer.etherlink.com/address/0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>Ethereum</td>
-  <td><InlineCopy href="https://etherscan.io/address/0xc9b53ab2679f573e480d01e0f49e2b5cfb7a3eab" code="0xc9b53ab2679f573e480d01e0f49e2b5cfb7a3eab">0xc9B...3EAb</InlineCopy></td>
+  <td><InlineCopy href="https://etherscan.io/address/0xc9b53ab2679f573e480d01e0f49e2b5cfb7a3eab" code="0xc9b53ab2679f573e480d01e0f49e2b5cfb7a3eab" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>Base</td>
-  <td><InlineCopy href="https://basescan.org/address/0x91f9cc2649ac70a071602cade9b0c1a5868af51d" code="0x91f9cc2649ac70a071602cade9b0c1a5868af51d">0x91F...f51D</InlineCopy></td>
+  <td><InlineCopy href="https://basescan.org/address/0x91f9cc2649ac70a071602cade9b0c1a5868af51d" code="0x91f9cc2649ac70a071602cade9b0c1a5868af51d" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>BNB Chain</td>
-  <td><InlineCopy href="https://bscscan.com/address/0x91F9cc2649ac70a071602cadE9b0C1A5868af51D" code="0x91F9cc2649ac70a071602cadE9b0C1A5868af51D">0x91F...f51D</InlineCopy></td>
+  <td><InlineCopy href="https://bscscan.com/address/0x91F9cc2649ac70a071602cadE9b0C1A5868af51D" code="0x91F9cc2649ac70a071602cadE9b0C1A5868af51D" abbreviate="5,4"></InlineCopy></td>
 </tr>
 <tr>
   <td>Arbitrum One</td>
-  <td><InlineCopy href="https://arbiscan.io/address/0x7424f00845777a06e21f0bd8873f814a8a814b2d" code="0x7424f00845777a06e21f0bd8873f814a8a814b2d">0x742...4B2D</InlineCopy></td>
+  <td><InlineCopy href="https://arbiscan.io/address/0x7424f00845777a06e21f0bd8873f814a8a814b2d" code="0x7424f00845777a06e21f0bd8873f814a8a814b2d" abbreviate="5,4"></InlineCopy></td>
 </tr>
 </tbody>
 </table>

--- a/docs/get-started/network-information.mdx
+++ b/docs/get-started/network-information.mdx
@@ -46,7 +46,7 @@ You can [set up your own node](/network/evm-nodes) if you need an endpoint witho
     </tr>
     <tr>
       <td>Tezos Smart Rollup address</td>
-      <td><InlineCopy code="sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf" href="https://tzkt.io/sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf">sr1Ghq...vZEf</InlineCopy></td>
+      <td><InlineCopy code="sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf" href="https://tzkt.io/sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf" abbreviate="6,4"></InlineCopy></td>
     </tr>
     <tr>
       <td>Chain ID</td>
@@ -103,7 +103,7 @@ You can [set up your own node](/network/evm-nodes) if you need an endpoint witho
     </tr>
     <tr>
       <td>Tezos Smart Rollup address</td>
-      <td><InlineCopy code="sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg" href="https://ghostnet.tzkt.io/sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg">sr18wx...mlqg</InlineCopy></td>
+      <td><InlineCopy code="sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg" href="https://ghostnet.tzkt.io/sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg" abbreviate="6,4"></InlineCopy></td>
     </tr>
     <tr>
       <td>Chain ID</td>

--- a/docs/governance/how-do-i-participate-in-governance.mdx
+++ b/docs/governance/how-do-i-participate-in-governance.mdx
@@ -27,23 +27,23 @@ You need the address of the correct governance contract to propose changes and v
 <tbody>
 <tr>
 <td>Smart Rollup</td>
-<td><InlineCopy code="sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf" href="https://tzkt.io/sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf">sr1Ghq...vZEf</InlineCopy></td>
-<td><InlineCopy code="sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg" href="https://ghostnet.tzkt.io/sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg">sr18wx...mlqg</InlineCopy></td>
+<td><InlineCopy code="sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf" href="https://tzkt.io/sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf" abbreviate="6,4"></InlineCopy></td>
+<td><InlineCopy code="sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg" href="https://ghostnet.tzkt.io/sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg" abbreviate="6,4"></InlineCopy></td>
 </tr>
 <tr>
 <td>Kernel governance</td>
-<td><InlineCopy code="KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J" href="https://better-call.dev/mainnet/KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J">KT1H5p...Va6J</InlineCopy></td>
-<td><InlineCopy code="KT1HfJb718fGszcgYguA4bfTjAqe1BEmFHkv" href="https://better-call.dev/ghostnet/KT1HfJb718fGszcgYguA4bfTjAqe1BEmFHkv">KT1HfJ...FHkv</InlineCopy></td>
+<td><InlineCopy code="KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J" href="https://better-call.dev/mainnet/KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J" abbreviate="6,4"></InlineCopy></td>
+<td><InlineCopy code="KT1HfJb718fGszcgYguA4bfTjAqe1BEmFHkv" href="https://better-call.dev/ghostnet/KT1HfJb718fGszcgYguA4bfTjAqe1BEmFHkv" abbreviate="6,4"></InlineCopy></td>
 </tr>
 <tr>
 <td>Kernel security governance</td>
-<td><InlineCopy code="KT1N5MHQW5fkqXkW9GPjRYfn5KwbuYrvsY1g" href="https://better-call.dev/mainnet/KT1N5MHQW5fkqXkW9GPjRYfn5KwbuYrvsY1g">KT1N5M...sY1g</InlineCopy></td>
-<td><InlineCopy code="KT1QDgF5pBkXEizj5RnmagEyxLxMTwVRpmYk" href="https://better-call.dev/ghostnet/KT1QDgF5pBkXEizj5RnmagEyxLxMTwVRpmYk">KT1QDg...pmYk</InlineCopy></td>
+<td><InlineCopy code="KT1N5MHQW5fkqXkW9GPjRYfn5KwbuYrvsY1g" href="https://better-call.dev/mainnet/KT1N5MHQW5fkqXkW9GPjRYfn5KwbuYrvsY1g" abbreviate="6,4"></InlineCopy></td>
+<td><InlineCopy code="KT1QDgF5pBkXEizj5RnmagEyxLxMTwVRpmYk" href="https://better-call.dev/ghostnet/KT1QDgF5pBkXEizj5RnmagEyxLxMTwVRpmYk" abbreviate="6,4"></InlineCopy></td>
 </tr>
 <tr>
 <td>Sequencer committee</td>
-<td><InlineCopy code="KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF" href="https://better-call.dev/mainnet/KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF">KT1NcZ...BDGF</InlineCopy></td>
-<td><InlineCopy code="KT1FRzozuzFMWLimpFeSdADHTMxzU8KtgCr9" href="https://better-call.dev/ghostnet/KT1FRzozuzFMWLimpFeSdADHTMxzU8KtgCr9">KT1FRz...gCr9</InlineCopy></td>
+<td><InlineCopy code="KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF" href="https://better-call.dev/mainnet/KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF" abbreviate="6,4"></InlineCopy></td>
+<td><InlineCopy code="KT1FRzozuzFMWLimpFeSdADHTMxzU8KtgCr9" href="https://better-call.dev/ghostnet/KT1FRzozuzFMWLimpFeSdADHTMxzU8KtgCr9" abbreviate="6,4"></InlineCopy></td>
 </tr>
 </tbody>
 </table>

--- a/src/components/InlineCopy/index.jsx
+++ b/src/components/InlineCopy/index.jsx
@@ -5,16 +5,20 @@ import styles from './styles.module.css';
 import Link from '@docusaurus/Link';
 
 import CopyButton from '@site/src/components/CopyButton';
+import { getAbbreviation } from '@site/src/utils';
 
-export default function InlineCopy({ code, href, children }) {
+// For the abbreviate property, pass two numbers separated by a comma
+export default function InlineCopy({ code, href, abbreviate, children }) {
+  // If abbreviate, automatically abbreviate the code as an address
+  const codeToShow = abbreviate ? getAbbreviation(code, abbreviate) : children || code;
   return (
     <div className={clsx(styles.container)}>
       {href ?
         <Link to={href} className={clsx(styles.link)}>
-          <code>{children || code}</code>
+          <code>{codeToShow}</code>
         </Link>
       :
-        <code>{children || code}</code>
+        <code>{codeToShow}</code>
       }
       <CopyButton code={code} />
     </div>

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -1,0 +1,14 @@
+// Abbreviate account addresses
+// Pass two numbers separated by a comma
+// for the number of characters at the start and the end
+export const getAbbreviation = (str, pattern) => {
+  const [start, end] = pattern.split(',').map((num) => parseInt(num, 10));
+  if ( isNaN(start) || isNaN(end) ) {
+    throw 'Pass two numbers separated by a comma to abbreviate an address; received: ' + pattern;
+  }
+  // If the abbreviation is too short, return the whole thing
+  if (start + end >= str.length) {
+    return str;
+  }
+  return str.substring(0, start) + '...' + str.substring(str.length - end);
+}

--- a/test/mocha/utils.test.mjs
+++ b/test/mocha/utils.test.mjs
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+
+import { getAbbreviation } from '../../src/utils.mjs';
+
+describe('Inline copy component', () => {
+  it('Abbreviates addresses correctly', () => {
+    expect(getAbbreviation('0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb', '5,4'))
+      .to.equal('0xc9B...3EAb');
+    expect(getAbbreviation('sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf', '6,4'))
+      .to.equal('sr1Ghq...vZEf');
+    expect(getAbbreviation('1234567890', '6,4'))
+      .to.equal('1234567890');
+    expect(getAbbreviation('123', '6,4'))
+      .to.equal('123');
+  });
+
+  it('Throws errors correctly', () => {
+    expect(() => getAbbreviation('ABC', 'DEF')).to.throw();
+  })
+});


### PR DESCRIPTION
We have a component that allows you to add an inline code copy button. We have been manually abbreviating addresses to show in the inline portion, but this abbreviation is manual.

This PR adds an `abbreviation` property to the component. You pass the number of characters to show at the start and end, separated by a comma, and the component automatically abbreviates the code. The component is smart enough to return the entire text if the abbreviation would be shorter or equal to the full text. I've updated the pages that use the component to abbreviate addresses so the output is the same. PR includes tests.