### PR TITLE
Update links to octez.tezos.com/docs

### DIFF
--- a/docs/governance/how-do-i-participate-in-governance.mdx
+++ b/docs/governance/how-do-i-participate-in-governance.mdx
@@ -10,7 +10,7 @@ The voting power of a baker is the amount of tez that it has staked plus the tez
 
 Separate contracts manage the kernel updates, security updates, and the Sequencer Committee, so to interact with them, bakers send transactions to those contracts, such as with the Octez client.
 The addresses of the governance contracts are specified in Etherlink's kernel.
-For information about the Octez client, see [Command Line Interface](https://tezos.gitlab.io/active/cli-commands.html) in the Octez documentation.
+For information about the Octez client, see [Command Line Interface](https://octez.tezos.com/docs/active/cli-commands.html) in the Octez documentation.
 
 ## Governance contract addresses
 

--- a/docs/network/architecture.md
+++ b/docs/network/architecture.md
@@ -6,7 +6,7 @@ Etherlink's main components are its nodes and the sequencer.
 The sequencer and nodes handle blocks, but they create and handle blocks in a way different from Tezos layer 1.
 Some major differences are that only the sequencer can create blocks and that the timing for blocks changes based on the demand.
 
-These components are instances of binaries in the [Octez software suite](https://tezos.gitlab.io/introduction/tezos.html).
+These components are instances of binaries in the [Octez software suite](https://octez.tezos.com/docs/introduction/tezos.html).
 
 ## High-level diagram
 
@@ -51,7 +51,7 @@ They forward these transactions to the sequencer and receive transactions from t
 They also check Smart Rollup nodes to verify that these transactions make it to Tezos layer 1.
 
 - Smart Rollup nodes (`octez-smart-rollup-node`): Smart Rollup nodes are Octez daemons that run the kernel of a Tezos Smart Rollup.
-For more information about Smart Rollup nodes in general, see [Smart Rollup node](https://tezos.gitlab.io/shell/smart_rollup_node.html) in the Octez documentation.
+For more information about Smart Rollup nodes in general, see [Smart Rollup node](https://octez.tezos.com/docs/shell/smart_rollup_node.html) in the Octez documentation.
 
   Etherlink Smart Rollup nodes run the kernel for the Etherlink Smart Rollup and store the state of the Etherlink blockchain from the perspective of Tezos layer 1.
   They monitor the Tezos layer 1 Smart Rollup inbox, filter the inbox to Etherlink-related messages, process them, and update their states.
@@ -67,7 +67,7 @@ For more information about Smart Rollup nodes in general, see [Smart Rollup node
      - The sequencer can use a node running in batcher mode to publish transactions to layer 1.
      It can also use a node running in operator mode to publish transactions.
 
-  For more information about Smart Rollup nodes in general, see [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) on docs.tezos.com and [Smart Rollup Node](https://tezos.gitlab.io/shell/smart_rollup_node.html) in the Octez documentation.
+  For more information about Smart Rollup nodes in general, see [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) on docs.tezos.com and [Smart Rollup Node](https://octez.tezos.com/docs/shell/smart_rollup_node.html) in the Octez documentation.
 
 - Tezos layer 1 nodes (`octez-node`): Layer 1 nodes are responsible for the state of layer 1.
 In addition to ordinary layer 1 transactions, they receive Etherlink transactions from the sequencer.

--- a/docs/network/monitoring.md
+++ b/docs/network/monitoring.md
@@ -55,7 +55,7 @@ The metric names in the table omit the namespace and subsystem for readability, 
 | bootstrapping                  | gauge     | 0.0 if the EVM node is caught up with its upstream EVM node or 1.0 if it is in the process of bootstrapping            | Observer, RPC       |
 | head                           | gauge     | Level of the node’s head                                                                                               | all                 |
 | confirmed_head                 | gauge     | Confirmed level (smart rollup node's head, ie as registered on L1)                                                     | all                 |
-| gas_price                      | gauge     | Base gas price of the last block                                                                                       | sequencer, observer | 
+| gas_price                      | gauge     | Base gas price of the last block                                                                                       | sequencer, observer |
 | info                           | gauge     | Information about the kernel (commit hash and date), the node (mode)  and the targeted rollup (smart_rollup_address)   | all                 |
 | block_process_time_histogram   | histogram | The time the EVM node spent processing a block. Buckets : [0.1; 0.1; 0.5; 1.; 2.; 5.; 10.; infinity] (in seconds)      | Sequencer, observer |
 | time_processed                 | counter   | Time to process blocks                                                                                                 | Sequencer, observer |
@@ -187,10 +187,10 @@ The target address of the node exporter is typically `localhost:9100`.
 The node outputs logs in the `<DATA_DIR>/daily_logs` directory for major events
 (such as block production, connection to rollup node, etc) and a separate set of
 logs for the inner working of the internal EVM (or, more precisely, the kernel)
-in the `<DATA_DIR>/kernel_logs`. 
+in the `<DATA_DIR>/kernel_logs`.
 
-The standards logs are output in files with a daily rotation and a retention 
-period of 5 days. They are limited to `INFO` and `ERROR` by default, but the 
+The standards logs are output in files with a daily rotation and a retention
+period of 5 days. They are limited to `INFO` and `ERROR` by default, but the
 EVM node can be started with the option `--verbose` for more.
 
 ```
@@ -215,23 +215,23 @@ The EVM logs are stored in different files according to the context of the EVM c
 ### Scraping logs with Loki
 
 Scraping logs makes them more easily searchable, and allows creating metrics to
-be used in monitoring. 
+be used in monitoring.
 
 We suggest using [Loki](https://github.com/grafana/loki) for that purpose.
-Loki is a server that can be queried for logs, similar to what prometheus is 
+Loki is a server that can be queried for logs, similar to what prometheus is
 for metrics. It relies on an agent to scrape and send the logs, we suggest Promtail.
 Promtail will scrape the logs and push them to the Loki instance which will make
 them available to the dashboard.
 
-To install follow the [instructions on the grafana website](https://grafana.com/docs/loki/latest/setup/install/). 
+To install follow the [instructions on the grafana website](https://grafana.com/docs/loki/latest/setup/install/).
 Note that we don't discuss using the `Alloy` agent, but rather `Promtail`.
-To install using a package manager, see the [install locally](https://grafana.com/docs/loki/latest/setup/install/local/) 
+To install using a package manager, see the [install locally](https://grafana.com/docs/loki/latest/setup/install/local/)
 section, to add the grafana package repository.
 
 Install Loki on the graphana server and Promtail on the EVM server.
 
-Once both are installed, you need to add the scraping job to the Promtail 
-configuration file (e.g. `/etc/promtail/config.yaml`) and specify the target 
+Once both are installed, you need to add the scraping job to the Promtail
+configuration file (e.g. `/etc/promtail/config.yaml`) and specify the target
 Loki server.
 
 ```yaml
@@ -241,13 +241,13 @@ clients:
 
 You must also configure a parsing pipeline for the logs.
 Below is an example of a pipeline suitable for the daily logs. It uses `grep`
-to extract the event's name from the log, to make searching the logs easier. 
-Alternatively, we present [later](#adding-log-sinks) a method to produce logs in a json format, and the 
+to extract the event's name from the log, to make searching the logs easier.
+Alternatively, we present [later](#adding-log-sinks) a method to produce logs in a json format, and the
 appropriate Promtail pipeline.
 
 ```yaml
 scrape_configs:
-- job_name: "evm-node-log-exporter" 
+- job_name: "evm-node-log-exporter"
   pipeline_stages:
     - regex:
         expression: "^(?P<time>\\S+)\\s*\\[(?P<event>\\S+)\\](?P<msg>.*)$"
@@ -277,18 +277,18 @@ so if Loki is installed on the same server:
 http://localhost:3100/loki/api/v1/push
 ```
 
-Make sure that the Promtail daemon is able to access the log files. If it's 
-installed as a service, an easy way is to make the `promtail` user part of the 
+Make sure that the Promtail daemon is able to access the log files. If it's
+installed as a service, an easy way is to make the `promtail` user part of the
 same group as the user used to run the EVM node.
 
 ### Adding log sinks
 
-The EVM Node uses the same [logging features](https://tezos.gitlab.io/user/logging.html#file-descriptor-sinks)
-as the [octez node](https://tezos.gitlab.io/). It is possible to add new 
-`sinks` using [environment variables](https://tezos.gitlab.io/user/logging.html#environment-variables).
+The EVM Node uses the same [logging features](https://octez.tezos.com/docs/user/logging.html#file-descriptor-sinks)
+as the [octez node](https://octez.tezos.com/docs/). It is possible to add new
+`sinks` using [environment variables](https://octez.tezos.com/docs/user/logging.html#environment-variables).
 
-For example, the following definition will add logs in json format, with a 
-daily rotation, 4 file retention, with `rw-r-----` unix rights, in the 
+For example, the following definition will add logs in json format, with a
+daily rotation, 4 file retention, with `rw-r-----` unix rights, in the
 (fictional) `/some/data/dir/json_daily_logs` directory.
 
 ```
@@ -307,7 +307,7 @@ Such files can be scraped using the following Promtail configuration.
 This will create a json event containing only the `event` of each log line.
 
 ```yaml
-- job_name: "evm-node-json-log-exporter" 
+- job_name: "evm-node-json-log-exporter"
   static_configs:
     - targets:
       - 127.0.0.1
@@ -321,7 +321,7 @@ This will create a json event containing only the `event` of each log line.
       source: event-sink
       expressions:
         event-name: event.keys(@)[0]
-        event: event.* | [0] 
+        event: event.* | [0]
         timestamp: time_stamp
   - labels:
       event: event-name

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -7,7 +7,7 @@ Public Smart Rollup nodes for Etherlink are not yet available, so you must run y
 
 :::note
 
-In this context, an _Etherlink Smart Rollup node_ is an [Octez Smart Rollup node](https://tezos.gitlab.io/shell/smart_rollup_node.html) that runs the Etherlink kernel.
+In this context, an _Etherlink Smart Rollup node_ is an [Octez Smart Rollup node](https://octez.tezos.com/docs/shell/smart_rollup_node.html) that runs the Etherlink kernel.
 This kernel is a Rust program compiled in WASM implementing the semantics of Etherlink blocks and transactions.
 
 :::
@@ -30,13 +30,13 @@ As described in [Smart Rollups](https://docs.tezos.com/architecture/smart-rollup
 The best way to run a node that can post commitments is to start with a node in observer mode, verify that it works, and convert it to maintenance mode.
 Maintenance mode is similar to operator mode but it does not require settings for batching operations, which are required only for sequencer nodes.
 
-For more information on modes, see [Smart Rollup node](https://tezos.gitlab.io/shell/smart_rollup_node.html) in the Octez documentation.
+For more information on modes, see [Smart Rollup node](https://octez.tezos.com/docs/shell/smart_rollup_node.html) in the Octez documentation.
 
 ## References
 
 Make sure that you understand the interaction between different nodes as described in [Etherlink architecture](/network/architecture).
 
-For more information about Smart Rollup nodes in general, see [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) on docs.tezos.com and [Smart Rollup Node](https://tezos.gitlab.io/shell/smart_rollup_node.html) in the Octez documentation.
+For more information about Smart Rollup nodes in general, see [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) on docs.tezos.com and [Smart Rollup Node](https://octez.tezos.com/docs/shell/smart_rollup_node.html) in the Octez documentation.
 
 ## Starting the Smart Rollup node in observer mode
 
@@ -181,8 +181,8 @@ Converting the observer node to maintenance mode requires these prerequisites:
 
    In most cases, you set these accounts up on another machine and use the Octez remote signer (`octez-signer`) to allow the Smart Rollup node to use them remotely.
    You can use a Ledger device to secure the keys.
-   For more information, see [Key management](https://tezos.gitlab.io/user/key-management.html) in the Octez documentation.
-   You must also set up security to prevent anyone but your Smart Rollup node from using the remote signer as described in [Secure the connection](https://tezos.gitlab.io/user/key-management.html#secure-the-connection).
+   For more information, see [Key management](https://octez.tezos.com/docs/user/key-management.html) in the Octez documentation.
+   You must also set up security to prevent anyone but your Smart Rollup node from using the remote signer as described in [Secure the connection](https://octez.tezos.com/docs/user/key-management.html#secure-the-connection).
 
    The following instructions include information about using the remote signer.
 
@@ -206,7 +206,7 @@ Follow these steps to convert a Smart Rollup node from observer mode to maintena
       octez-signer launch socket signer -a localhost
       ```
 
-      For more information about configuring the remote signer, see [Signer configuration](https://tezos.gitlab.io/user/key-management.html#signer-configuration) in the Octez documentation.
+      For more information about configuring the remote signer, see [Signer configuration](https://octez.tezos.com/docs/user/key-management.html#signer-configuration) in the Octez documentation.
 
    1. Get the addresses of the accounts on the remote signer by running this command:
 

--- a/docs/progress/changelogs.md
+++ b/docs/progress/changelogs.md
@@ -7,4 +7,4 @@ See these pages for Etherlink changelogs:
 - Octez EVM node: https://gitlab.com/tezos/tezos/-/blob/master/etherlink/CHANGES_NODE.md
 - Etherlink kernel: https://gitlab.com/tezos/tezos/-/blob/master/etherlink/CHANGES_KERNEL.md
 
-For other Octez changelogs, see https://tezos.gitlab.io/CHANGES.html.
+For other Octez changelogs, see https://octez.tezos.com/docs/CHANGES.html.


### PR DESCRIPTION
The Octez docs have moved to octez.tezos.com/docs. I checked each updated link.