### PR TITLE
Correct reference to the kernel governance contract

### DIFF
--- a/docs/governance/how-do-i-participate-in-governance.mdx
+++ b/docs/governance/how-do-i-participate-in-governance.mdx
@@ -58,7 +58,7 @@ The commands are the same for kernel upgrades and security upgrades but they tar
 You can get information about the current period at https://governance.etherlink.com.
 
 To get information about the current state of the kernel or security governance contract directly from the contract, connect the Octez client to an active node and call the contract's `get_voting_state` view.
-For example, this Octez client command calls this view for the security governance contract on Mainnet:
+For example, this Octez client command calls this view for the kernel governance contract on Mainnet:
 
 ```bash
 octez-client -E https://mainnet.ecadinfra.com \


### PR DESCRIPTION
The example says security governance but gives the address of kernel governance. This PR corrects that.