### PR TITLE
Update build instructions for Claypso

### DIFF
--- a/docs/network/building-kernel.md
+++ b/docs/network/building-kernel.md
@@ -114,14 +114,14 @@ Before you begin, make sure that you have these prerequisites installed:
 Follow these steps to build the installer kernel:
 
 1. Clone the repository at https://gitlab.com/tezos/tezos.
-1. Check out the commit with the hash `b9f6c9138719220db83086f0548e49c5c4c8421f`.
+1. Check out the commit with the hash `604663095ad8d9f537a7035821bc78112c3b865b`.
 1. Build the kernel by running this command from the root directory:
 
    ```bash
    ./etherlink/scripts/build-wasm.sh
    ```
 
-   This command creates the file `etherlink/kernels-b9f6c9138719220db83086f0548e49c5c4c8421f/evm_kernel.wasm`.
+   This command creates the file `etherlink/kernels-604663095ad8d9f537a7035821bc78112c3b865b/evm_kernel.wasm`.
 
 1. Run this command to install the installer kernel build dependencies:
 
@@ -147,7 +147,7 @@ Follow these steps to build the installer kernel:
 
    ```bash
    smart-rollup-installer get-reveal-installer \
-     -u etherlink/kernels-b9f6c9138719220db83086f0548e49c5c4c8421f/evm_kernel.wasm \
+     -u etherlink/kernels-604663095ad8d9f537a7035821bc78112c3b865b/evm_kernel.wasm \
      -o installer.hex \
      -P wasm_2_0_0 \
      -S setup_file.yml \

--- a/docs/network/building-kernel.md
+++ b/docs/network/building-kernel.md
@@ -136,9 +136,9 @@ Follow these steps to build the installer kernel:
      --sequencer edpktufVZGs2JmEwHSFLdA7XHXotmnkD2Nwr75ACpxUr1iKUWzYFHJ      \
      --delayed-bridge KT1AZeXH8qUdLMfwN2g7iwiYYSZYG4RrwhCj                   \
      --ticketer KT1CeFqjJRJPNVvhvznQrWfHad2jCiDZ6Lyj                         \
-     --sequencer-governance KT1NcZQ3y9Wv32BGiUfD2ZciSUz9cY1DBDGF             \
-     --kernel-governance KT1H5pCmFuhAwRExzNNrPQFKpunJx1yEVa6J                \
-     --kernel-security-governance KT1N5MHQW5fkqXkW9GPjRYfn5KwbuYrvsY1g       \
+     --sequencer-governance KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U             \
+     --kernel-governance KT1FPG4NApqTJjwvmhWvqA14m5PJxu9qgpBK                \
+     --kernel-security-governance KT1UvCsnXpLAssgeJmrbQ6qr3eFkYXxsTG9U       \
      --sequencer-pool-address 0xCF02B9Ca488f8F6F4E28e37AA1bDD16b3F1b2aD8     \
      --delayed-inbox-min-levels 1600 --remove-whitelist
    ```


### PR DESCRIPTION
Update build instructions for Calypso:

- New kernel hash
- New commit to build from
- New governance contracts