### PR TITLE
Note about timing for layer 1 blocks affecting governance period lengths

### DIFF
--- a/docs/governance/how-is-etherlink-governed.md
+++ b/docs/governance/how-is-etherlink-governed.md
@@ -9,6 +9,17 @@ Etherlink has separate governance processes for the kernel, for security inciden
 To ensure that decisions accurately reflect the consensus of the Etherlink community, all three governance processes are designed with the same robust safeguards.
 Like Tezos's governance process, Etherlink's governance process promotes transparency and fairness in decision-making.
 
+:::note
+
+Each Etherlink governance period lasts a certain number of layer 1 blocks.
+The minimum time between layer 1 blocks is set by the `minimal_block_delay` constant.
+If the first baker chosen to bake a block does not bake it after a certain amount of time, other bakers have the opportunity to bake it, which increases the time between blocks.
+
+For this reason, the lengths of Etherlink governance periods listed below are approximate times.
+The real-world duration of governance periods can be longer, depending on the actual timing of layer 1 blocks.
+
+:::
+
 ## Governance information
 
 For information about governance proposals and updates, see https://governance.etherlink.com.


### PR DESCRIPTION
The governance periods can be a bit longer because of what we call "block drift."
<img width="603" alt="Screenshot 2025-03-06 at 10 04 02 AM" src="https://github.com/user-attachments/assets/846c0284-61ec-4a72-b406-1fdcfdc3616b" />
