### PR TITLE
Add EVM version to addl info in endpoint support

### DIFF
--- a/docs/building-on-etherlink/endpoint-support.md
+++ b/docs/building-on-etherlink/endpoint-support.md
@@ -461,6 +461,10 @@ The Etherlink EVM node supports these [ethers.js](https://docs.ethers.org/v6/) m
   </thead>
   <tbody>
     <tr>
+      <td>EVM version</td>
+      <td><code>Shanghai</code></td>
+    </tr>
+    <tr>
       <td>Whitelisting Fireblocks IP addresses</td>
       <td>Not Supported</td>
     </tr>


### PR DESCRIPTION
People are missing the mention of EVM version on the network information page so add it here, too.