### PR TITLE
Built in remote signer

### DIFF
--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -199,6 +199,12 @@ Follow these steps to convert a Smart Rollup node from observer mode to maintena
 
       To import accounts from a Ledger device, get the address of the connected device by running the command `octez-signer list connected ledgers` and then import the key from the ledger by running the command `octez-signer import secret key <REMOTE_OPERATOR> ledger://XXXXXXXXXX`, where `ledger://XXXXXXXXXX` is the address of the connected device.
 
+   1. Get the addresses of the accounts on the remote signer by running this command:
+
+      ```bash
+      octez-signer list known addresses
+      ```
+
    1. Configure the remote signer to allow other Octez programs to sign with those accounts.
    For example, this command makes the keys available over the TCP protocol on localhost:
 
@@ -207,12 +213,6 @@ Follow these steps to convert a Smart Rollup node from observer mode to maintena
       ```
 
       For more information about configuring the remote signer, see [Signer configuration](https://octez.tezos.com/docs/user/key-management.html#signer-configuration) in the Octez documentation.
-
-   1. Get the addresses of the accounts on the remote signer by running this command:
-
-      ```bash
-      octez-signer list known addresses
-      ```
 
    1. Ensure that the remote signer runs persistently.
 

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -278,6 +278,21 @@ Follow these steps to convert a Smart Rollup node from observer mode to maintena
      --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
    ```
 
+   If you are using a remote signer, pass the address of the remote signer in the `--remote-signer` argument before the `run` command, as in this example:
+
+   ```bash
+   octez-smart-rollup-node \
+     --endpoint <MY_LAYER_1_NODE> \
+     --remote-signer tcp://localhost:7732/ \
+     run maintenance for sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf \
+     with operators <REMOTE_OPERATOR> \
+     cementing:<SECONDARY_ACCOUNT> \
+     executing_outbox:<SECONDARY_ACCOUNT> \
+     --rpc-addr 0.0.0.0 \
+     --data-dir <SR_DATA_DIR> \
+     --pre-images-endpoint https://snapshots.eu.tzinit.org/etherlink-mainnet/wasm_2_0_0
+   ```
+
 1. Verify that the Smart Rollup node is running by querying it.
 For example, this query gets the health of the node:
 


### PR DESCRIPTION
The new version of the SR node has a `--remote-signer` option which can make it easier to us ea remote signer if the URL to the signer changes.