### PR TITLE
Integration info

### DIFF
--- a/docs/building-on-etherlink/endpoint-support.md
+++ b/docs/building-on-etherlink/endpoint-support.md
@@ -398,8 +398,8 @@ For information about these endpoints, see the Geth documentation at https://get
   <tbody>
     <tr>
       <td>`debug_traceTransaction`</td>
-      <td>Partially</td>
-      <td>Supported on testnet but not Mainnet</td>
+      <td>Yes</td>
+      <td></td>
     </tr>
     <tr>
       <td>`eth_call`</td>

--- a/docs/building-on-etherlink/endpoint-support.md
+++ b/docs/building-on-etherlink/endpoint-support.md
@@ -397,6 +397,11 @@ For information about these endpoints, see the Geth documentation at https://get
   </thead>
   <tbody>
     <tr>
+      <td>`debug_traceCall`</td>
+      <td>Partially</td>
+      <td>Supports only callTracer and structLogger, not custom call tracers</td>
+    </tr>
+    <tr>
       <td>`debug_traceTransaction`</td>
       <td>Yes</td>
       <td></td>

--- a/docs/get-started/network-information.mdx
+++ b/docs/get-started/network-information.mdx
@@ -57,7 +57,7 @@ You can [set up your own node](/network/evm-nodes) if you need an endpoint witho
       <td><code>42793</code></td>
     </tr>
     <tr>
-      <td>Currency Symbol</td>
+      <td>Currency Symbol (native token)</td>
       <td><code>XTZ</code></td>
     </tr>
     <tr>
@@ -118,7 +118,7 @@ You can [set up your own node](/network/evm-nodes) if you need an endpoint witho
       <td><code>128123</code></td>
     </tr>
     <tr>
-      <td>Currency Symbol</td>
+      <td>Currency Symbol (native token)</td>
       <td><code>XTZ</code></td>
     </tr>
     <tr>
@@ -139,3 +139,16 @@ You can [set up your own node](/network/evm-nodes) if you need an endpoint witho
     </tr>
   </tbody>
 </table>
+
+## Technical information
+
+Feature | Details |
+--- | --- |
+Genesis date | 2nd May 2024 (Mainnet), 15th November 2023 (Testnet)
+EVM-compatible | Yes, up to version Shanghai
+Block speed | Variable; see [Architecture](/network/architecture)
+Docker image | https://hub.docker.com/r/tezos/tezos-bare images that start with `octez-evm-node`
+Debugging | Supported via standard [Ethereum endpoints](/building-on-etherlink/endpoint-support)
+Tracing | Supported via standard [Ethereum endpoints](/building-on-etherlink/endpoint-support)
+Monitoring | Supported; see [Monitoring Etherlink nodes](/network/monitoring)
+WebSockets | Experimental; see [Getting updates with WebSockets](/building-on-etherlink/websockets)

--- a/docs/get-started/network-information.mdx
+++ b/docs/get-started/network-information.mdx
@@ -3,6 +3,7 @@ title: Network information
 ---
 
 import InlineCopy from '@site/src/components/InlineCopy';
+import Link from '@docusaurus/Link';
 
 For current and historical status information for Etherlink, see https://status.etherlink.com.
 
@@ -152,3 +153,95 @@ Debugging | Supported via standard [Ethereum endpoints](/building-on-etherlink/e
 Tracing | Supported via standard [Ethereum endpoints](/building-on-etherlink/endpoint-support)
 Monitoring | Supported; see [Monitoring Etherlink nodes](/network/monitoring)
 WebSockets | Experimental; see [Getting updates with WebSockets](/building-on-etherlink/websockets)
+
+## Precompiled contracts
+
+The precompiled contracts on Etherlink are listed in the [`mod.rs`](https://gitlab.com/tezos/tezos/-/blob/master/etherlink/kernel_evm/evm_execution/src/precompiles/mod.rs#L181) file.
+
+These precompiled contracts are specific to Etherlink:
+
+<table class="customTableContainer">
+  <thead>
+    <tr>
+      <th>Contract</th>
+      <th>Mainnet</th>
+      <th>Testnet</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><Link to="/bridging/bridging-tezos">XTZ withdrawal</Link></td>
+      <td><InlineCopy code="0xff00000000000000000000000000000000000001" href="https://explorer.etherlink.com/address/0xff00000000000000000000000000000000000001" abbreviate="5,4"></InlineCopy></td>
+      <td><InlineCopy code="0xff00000000000000000000000000000000000001" href="https://testnet.explorer.etherlink.com/address/0xff00000000000000000000000000000000000001" abbreviate="5,4"></InlineCopy></td>
+    </tr>
+    <tr>
+      <td><Link to="/bridging/bridging-fa">FA withdrawal</Link></td>
+      <td><InlineCopy code="0xff00000000000000000000000000000000000002" href="https://explorer.etherlink.com/address/0xff00000000000000000000000000000000000002" abbreviate="5,4"></InlineCopy></td>
+      <td><InlineCopy code="0xff00000000000000000000000000000000000002" href="https://testnet.explorer.etherlink.com/address/0xff00000000000000000000000000000000000002" abbreviate="5,4"></InlineCopy></td>
+    </tr>
+  </tbody>
+</table>
+
+Etherlink also includes these [Ethereum precompiled contracts](https://www.evm.codes/precompiled):
+
+<table class="customTableContainer">
+  <thead>
+    <tr>
+      <th>Contract</th>
+      <th>Mainnet</th>
+      <th>Testnet</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`ecrecover`</td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000001" href="https://explorer.etherlink.com/address/0x0000000000000000000000000000000000000001" abbreviate="5,4"></InlineCopy></td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000001" href="https://testnet.explorer.etherlink.com/address/0x0000000000000000000000000000000000000001" abbreviate="5,4"></InlineCopy></td>
+    </tr>
+    <tr>
+      <td>`sha256`</td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000002" href="https://explorer.etherlink.com/address/0x0000000000000000000000000000000000000002" abbreviate="5,4"></InlineCopy></td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000002" href="https://testnet.explorer.etherlink.com/address/0x0000000000000000000000000000000000000002" abbreviate="5,4"></InlineCopy></td>
+    </tr>
+    <tr>
+      <td>`ripemd160`</td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000003" href="https://explorer.etherlink.com/address/0x0000000000000000000000000000000000000003" abbreviate="5,4"></InlineCopy></td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000003" href="https://testnet.explorer.etherlink.com/address/0x0000000000000000000000000000000000000003" abbreviate="5,4"></InlineCopy></td>
+    </tr>
+    <tr>
+      <td>`identity`</td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000004" href="https://explorer.etherlink.com/address/0x0000000000000000000000000000000000000004" abbreviate="5,4"></InlineCopy></td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000004" href="https://testnet.explorer.etherlink.com/address/0x0000000000000000000000000000000000000004" abbreviate="5,4"></InlineCopy></td>
+    </tr>
+    <tr>
+      <td>`modexp`</td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000005" href="https://explorer.etherlink.com/address/0x0000000000000000000000000000000000000005" abbreviate="5,4"></InlineCopy></td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000005" href="https://testnet.explorer.etherlink.com/address/0x0000000000000000000000000000000000000005" abbreviate="5,4"></InlineCopy></td>
+    </tr>
+    <tr>
+      <td>`ecadd`</td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000006" href="https://explorer.etherlink.com/address/0x0000000000000000000000000000000000000006" abbreviate="5,4"></InlineCopy></td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000006" href="https://testnet.explorer.etherlink.com/address/0x0000000000000000000000000000000000000006" abbreviate="5,4"></InlineCopy></td>
+    </tr>
+    <tr>
+      <td>`ecmul`</td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000007" href="https://explorer.etherlink.com/address/0x0000000000000000000000000000000000000007" abbreviate="5,4"></InlineCopy></td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000007" href="https://testnet.explorer.etherlink.com/address/0x0000000000000000000000000000000000000007" abbreviate="5,4"></InlineCopy></td>
+    </tr>
+    <tr>
+      <td>`ecpairing`</td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000008" href="https://explorer.etherlink.com/address/0x0000000000000000000000000000000000000008" abbreviate="5,4"></InlineCopy></td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000008" href="https://testnet.explorer.etherlink.com/address/0x0000000000000000000000000000000000000008" abbreviate="5,4"></InlineCopy></td>
+    </tr>
+    <tr>
+      <td>`blake2f`</td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000009" href="https://explorer.etherlink.com/address/0x0000000000000000000000000000000000000009" abbreviate="5,4"></InlineCopy></td>
+      <td><InlineCopy code="0x0000000000000000000000000000000000000009" href="https://testnet.explorer.etherlink.com/address/0x0000000000000000000000000000000000000009" abbreviate="5,4"></InlineCopy></td>
+    </tr>
+    <tr>
+      <td>`kzg_point_evaluation`</td>
+      <td><InlineCopy code="0x000000000000000000000000000000000000000a" href="https://explorer.etherlink.com/address/0x000000000000000000000000000000000000000a" abbreviate="5,4"></InlineCopy></td>
+      <td><InlineCopy code="0x000000000000000000000000000000000000000a" href="https://testnet.explorer.etherlink.com/address/0x000000000000000000000000000000000000000a" abbreviate="5,4"></InlineCopy></td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/network/evm-nodes.md
+++ b/docs/network/evm-nodes.md
@@ -229,3 +229,7 @@ For example, this command gets the number of the most recent block in hexadecima
 ```bash
 curl -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber"}' http://localhost:8545
 ```
+
+## Stopping the node
+
+The EVM node respects SIGTERM and exits cleanly when stopped, so you can stop it in any way that you would ordinarily stop a program on your system.

--- a/docs/network/smart-rollup-nodes.md
+++ b/docs/network/smart-rollup-nodes.md
@@ -337,6 +337,9 @@ Then you can recover the node's bonded tez and stop the node.
 If you stop the node before waiting for its last commitment to be cemented, the bonded tez is at risk if other nodes challenge that commitment and your node is not online to defend it in the Smart Rollup refutation game.
 For more information, see [Smart Rollups](https://docs.tezos.com/architecture/smart-rollups) on docs.tezos.com.
 
+If you are not running the node in a mode that posts commitments, you can stop the node in any way you want.
+The Smart Rollup node respects SIGTERM and exits cleanly when stopped.
+
 :::
 
 Follow these steps to stop an Etherlink Smart Rollup node:


### PR DESCRIPTION
Add some technical integration info that teams need to integrate Etherlink with other systems. Not 100% sure where to put all this but people need the info so it needs to be on here somewhere.

Preview:
https://docs-etherlink-git-integration-info-trili-tech.vercel.app/get-started/network-information#technical-information

Added info on:
- Genesis date
- EVM compatibility info
- Tracing, logging, and debugging info
- Block speed
- Native token
- Docker image
- Technical info about stopping the node
- List of precompiles
- Customizing the port for EVM and Smart Rollup nodes: covered in https://github.com/etherlinkcom/docs/pull/277
- eth_call supports stateOverrides: Covered in https://github.com/etherlinkcom/docs/pull/278
- debug_traceCall supports only callTracer and structLogger, not custom call tracers

Also verified that the list of supported endpoints is up to date.