### PR TITLE
Adjust CSS to make these tables overflow and use whole page

### DIFF
--- a/docs/building-on-etherlink/endpoint-support.md
+++ b/docs/building-on-etherlink/endpoint-support.md
@@ -15,7 +15,7 @@ For information about these endpoints, see [JSON-RPC API](https://ethereum.org/e
     <tr>
       <th>Endpoint</th>
       <th>Supported</th>
-      <th>Notes</th>
+      <th class="absorbingColumn">Notes</th>
     </tr>
   </thead>
   <tbody>
@@ -393,7 +393,7 @@ For information about these endpoints, see the Geth documentation at https://get
     <tr>
       <th>Endpoint</th>
       <th>Supported</th>
-      <th>Notes</th>
+      <th class="absorbingColumn">Notes</th>
     </tr>
   </thead>
   <tbody>
@@ -424,7 +424,7 @@ The Etherlink EVM node supports these [ethers.js](https://docs.ethers.org/v6/) m
     <tr>
       <th>Method</th>
       <th>Supported</th>
-      <th>Notes</th>
+      <th class="absorbingColumn">Notes</th>
     </tr>
   </thead>
   <tbody>
@@ -462,7 +462,7 @@ The Etherlink EVM node supports these [ethers.js](https://docs.ethers.org/v6/) m
   <thead>
     <tr>
       <th></th>
-      <th>Comments</th>
+      <th class="absorbingColumn">Comments</th>
     </tr>
   </thead>
   <tbody>

--- a/docs/building-on-etherlink/endpoint-support.md
+++ b/docs/building-on-etherlink/endpoint-support.md
@@ -1,5 +1,6 @@
 ---
 title: Ethereum endpoint support
+hide_table_of_contents: true
 ---
 
 Etherlink nodes use [Geth](https://geth.ethereum.org/) to provide access to both standard Ethereum RPC endpoints and Geth-specific RPC endpoints.
@@ -9,7 +10,7 @@ These tables list these endpoints and whether Etherlink supports them:
 
 For information about these endpoints, see [JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc) and the [Ethereum JSON-RPC Specification](https://ethereum.github.io/execution-apis/api-documentation/) in the Ethereum documentation.
 
-<table class="customTableContainer">
+<table class="customTableContainer fullWidthTable">
   <thead>
     <tr>
       <th>Endpoint</th>
@@ -339,9 +340,9 @@ For information about these endpoints, see [JSON-RPC API](https://ethereum.org/e
       <td></td>
     </tr>
     <tr>
-      <td>`eth_subscribe` (experimental)</td>
+      <td>`eth_subscribe`</td>
+      <td>Experimental</td>
       <td>See <a href="/building-on-etherlink/websockets">Getting updates with WebSockets</a></td>
-      <td></td>
     </tr>
     <tr>
       <td>`eth_syncing`</td>
@@ -387,7 +388,7 @@ This table shows the Geth endpoints that Etherlink nodes support.
 All other Geth endpoints are not supported.
 For information about these endpoints, see the Geth documentation at https://geth.ethereum.org/docs.
 
-<table class="customTableContainer">
+<table class="customTableContainer fullWidthTable">
   <thead>
     <tr>
       <th>Endpoint</th>
@@ -418,7 +419,7 @@ For information about these endpoints, see the Geth documentation at https://get
 
 The Etherlink EVM node supports these [ethers.js](https://docs.ethers.org/v6/) methods:
 
-<table class="customTableContainer">
+<table class="customTableContainer fullWidthTable">
   <thead>
     <tr>
       <th>Method</th>
@@ -457,7 +458,7 @@ The Etherlink EVM node supports these [ethers.js](https://docs.ethers.org/v6/) m
 
 ## Additional information
 
-<table class="customTableContainer">
+<table class="customTableContainer fullWidthTable">
   <thead>
     <tr>
       <th></th>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -582,4 +582,7 @@ article img {
   .fullWidthTable {
     width: calc(90vw - 90%);
   }
+  .fullWidthTable .absorbingColumn {
+    width: 100%;
+  }
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -207,7 +207,7 @@ header.DocSearch-SearchBar {
 header.DocSearch-SearchBar .DocSearch-Form {
   border-radius: 40px;
   background: #151515 !important;
-  box-shadow: 0px 0px 6px 0px rgba(51, 232, 142, 0.40) !important; 
+  box-shadow: 0px 0px 6px 0px rgba(51, 232, 142, 0.40) !important;
 }
 .DocSearch-Dropdown .DocSearch-Dropdown-Container {
   background: #151515 !important;
@@ -530,7 +530,7 @@ article img {
   height: 1px;
 }
 .customTableContainer::-webkit-scrollbar-track {
-  background: #515151; 
+  background: #515151;
   box-shadow: 0px 0px 60px 0px rgba(56, 255, 156, 0.40);
   backdrop-filter: blur(60px);
 }
@@ -567,4 +567,19 @@ article img {
 }
 .customTableContainer tbody tr:nth-child(even) {
   background-color: #151515;
+}
+
+/* Use with hide_table_of_contents: true to use the full width of the page */
+@media (min-width: 996px) {
+  .fullWidthTable {
+    width: calc(90vw - 400px);
+  }
+  .fullWidthTable .absorbingColumn {
+    width: 100%;
+  }
+}
+@media (min-width: 1440px) {
+  .fullWidthTable {
+    width: calc(90vw - 90%);
+  }
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -469,7 +469,7 @@ article a[target="_blank"]:after {
 }
 
 article {
-  margin: auto;
+  margin: auto auto auto 40px;
 }
 @media screen and (min-width: 997px) {
   article {


### PR DESCRIPTION
The tables on the endpoint support page need to be wider to allow the text in the notes column show up. This isn't a great way to do it but it works for a wide range of page widths. I'm open to other suggestions.

Preview: https://docs-etherlink-git-custom-page-endpoints-trili-tech.vercel.app/building-on-etherlink/endpoint-support

Before:
![Screenshot 2025-03-18 at 2 09 33 PM](https://github.com/user-attachments/assets/49f2d667-2bf6-441e-a80b-a422546ec57b)


After:
![Screenshot 2025-03-18 at 2 10 29 PM](https://github.com/user-attachments/assets/39fd36ee-4640-48ad-8b2d-bdc7139e86cf)
