### PR TITLE
Calypso went live on 4 March 2025

### DIFF
--- a/docs/progress/upgrades.md
+++ b/docs/progress/upgrades.md
@@ -23,12 +23,7 @@ For more information, see [Announcing Bifröst: a 2nd upgrade proposal for Ether
 
 ## Calypso upgrade
 
-<!--
-TODO if promoted to Mainnet, update with the date of activation.
-If rejected, change this section to say that it was proposed but not approved.
--->
-
-The proposed Calypso upgrade to the Etherlink kernel was installed on Etherlink Testnet on 17 February 2025.
+The proposed Calypso upgrade to the Etherlink kernel went live on Etherlink Mainnet on 4 March 2025.
 
 This upgrade includes significant performance and reliability improvements, including:
 


### PR DESCRIPTION
Per the [Changelog](https://gitlab.com/tezos/tezos/-/blob/master/etherlink/CHANGES_KERNEL.md) Calypso was activated in block 7,056,139 on 4 March.