### PR TITLE
Clarify issue in gas price estimation that affects older EVM nodes

### DIFF
--- a/docs/building-on-etherlink/transactions.md
+++ b/docs/building-on-etherlink/transactions.md
@@ -4,12 +4,16 @@ title: Sending transactions
 
 import PublicRpcRateLimitNote from '@site/docs/conrefs/rate-limit.md';
 
+import GasPriceWarning from '@site/docs/conrefs/gas-price-warning.md';
+
 Etherlink supports the standard Ethereum `eth_call` and `eth_sendRawTransaction` RPC endpoints for calling smart contracts and sending transactions.
 
 - For a list of endpoints that Etherlink supports, see [Ethereum endpoint support](/building-on-etherlink/endpoint-support)
 - For more information about the endpoints on this page, see the reference for the Ethereum [JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc).
 
 <PublicRpcRateLimitNote />
+
+<GasPriceWarning />
 
 ## Calling read-only entrypoints
 

--- a/docs/conrefs/gas-price-warning.md
+++ b/docs/conrefs/gas-price-warning.md
@@ -1,0 +1,18 @@
+:::warning
+
+Versions of the EVM node before 0.25 had an issue with gas price estimation.
+As intended by the EVM specification, the node's implementation of the `eth_gasPrice` endpoint provides the current gas price.
+If a wallet uses that information to calculate the cost of a transaction and the gas price goes up, the wallet might not include enough of a transaction fee.
+In this case, the sequencer silently rejects the transaction.
+
+Starting with version 0.25, the EVM node's implementation of the `eth_gasPrice` endpoint includes an increased safety margin to help ensure that the transaction fee is sufficient.
+However, wallets may still not include a high enough transaction fee if the gas price increases rapidly or if they do not check the gas price often enough.
+For greater control, wallets and dApps can call the `eth_getBlockByNumber` endpoint, which includes the base fee for transactions in the `baseFeePerGas` field.
+
+If you are using an earlier version of the EVM node, you can increase the transaction fee to ensure that the sequencer will accept your transaction.
+Because the sequencer rejects these transactions silently, wallets may resubmit the transaction automatically, still with insufficient transaction fees.
+Most wallets periodically check the status of submitted transactions via the `eth_getTransactionByHash` and `eth_getTransactionReceipt` endpoints and update their information to show that they have failed, but it can take time before the wallet shows that the transaction has failed.
+
+If the gas price drops, the sequencer may eventually accept the transaction, but the better solution is to use the wallet's "speed up" function (available in most popular supported wallets), and increase the maximum base gas fee.
+
+:::

--- a/docs/network/fees.md
+++ b/docs/network/fees.md
@@ -2,6 +2,8 @@
 title: Fee structure
 ---
 
+import GasPriceWarning from '@site/docs/conrefs/gas-price-warning.md';
+
 Etherlink transactions include two fees:
 
 - The _execution fee_, sometimes known as the _gas fee_, is a fee for running the transaction.
@@ -16,6 +18,8 @@ Because the Etherlink sequencer orders transactions in first-come-first-served o
 The base fee of the transaction (in the Ethereum `max_fee_per_gas` [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) field) must be enough to cover these Etherlink fees.
 Etherlink ignores the priority fee in the `max_priority_fee_per_gas` field.
 If the transaction's base fee is not enough to cover Etherlink's fees, the transaction fails, even if the amount of the priority fee would be enough to cover the fee.
+
+<GasPriceWarning />
 
 ## Execution fee
 


### PR DESCRIPTION
Earlier versions of the EVM node don't always include enough margin for transaction fees. Mention the changes in 0.25 and what devs can do to adapt.

Preview: https://docs-etherlink-git-node-gas-price-issue-trili-tech.vercel.app/network/fees
