### PR TITLE
Style feedback widget similarly to the rest of the site

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -42,6 +42,19 @@
   --ifm-color-primary-lightest: #3cad6e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+
+  /* Feedback widget */
+  --feedback-primary-color: var(--ifm-color-primary-dark);
+  --feedback-secondary-color: #f1f3f4;
+  --feedback-light-color: #ccc;
+  --feedback-dark-color: #191919;
+  --feedback-text-color: var(--biel-button-dark-text-color);
+  --feedback-white-color: #fff;
+  --feedback-button-light-text-color: var(--biel-button-dark-text-color);
+  --feedback-button-light-bg-color: var(--ifm-color-primary-darkest);
+  --feedback-button-dark-bg-color: var(--ifm-color-primary-darkest);
+  --feedback-button-light-icon-color: var(--biel-button-dark-text-color);
+  --feedback-modal-input-text-color: var(--feedback-dark-color);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */


### PR DESCRIPTION
Style the feedback widget to look like the rest of the site. 

Before:

<img width="143" alt="Screenshot 2025-06-11 at 1 28 25 PM" src="https://github.com/user-attachments/assets/04a82487-e1cc-4392-b168-e4bb644465ab" />

<img width="593" alt="Screenshot 2025-06-11 at 1 28 50 PM" src="https://github.com/user-attachments/assets/0ffd39d5-33eb-4c32-844a-d49f2439b67d" />


After:
![Screenshot 2025-06-11 at 1 29 57 PM](https://github.com/user-attachments/assets/974ad049-612b-43e9-8c21-2d1d9e1621e9)


![Screenshot 2025-06-11 at 1 30 06 PM](https://github.com/user-attachments/assets/327628e4-bbff-41ed-81c6-bc26ebb30fda)

