### PR TITLE
Keep search box centered

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -168,7 +168,6 @@ nav.navbar {
   backdrop-filter: blur(12px);
 }
 .DocSearch-Modal {
-  position: fixed;
   top: -30px !important;
   border-radius: 40px !important;
   background: #151515 !important;


### PR DESCRIPTION
This problem seems to have been caused by the move to docusaurus 3.8.1 in https://github.com/etherlinkcom/docs/pull/316 but I'm not sure how.

You can check this fix in the preview: https://docs-etherlink-git-fix-search-position-trili-tech.vercel.app/

Currently when you open the search the search box appears at far right, not centered:

<img width="1504" alt="Screenshot 2025-06-17 at 4 04 33 PM" src="https://github.com/user-attachments/assets/b23bee56-3e6d-4191-bd19-543365bf3f0e" />


This change centers it again:

<img width="1504" alt="Screenshot 2025-06-17 at 4 05 00 PM" src="https://github.com/user-attachments/assets/2dbf1d1d-abe3-4a7c-89f3-0d0c706f8ac8" />
