### PR TITLE
Typos

### DIFF
--- a/docs/bridging/bridging-fa-how.md
+++ b/docs/bridging/bridging-fa-how.md
@@ -72,7 +72,8 @@ The process of bridging FA-compatible tokens from Etherlink to layer 1 (also kno
 1. The proxy contract sends the ticket to the helper contract by putting it in a transaction in the Smart Rollup outbox.
 This transaction includes the target layer 1 address.
 
-This outbox message becomes part of Etherlink's commitment to its state.
+   This outbox message becomes part of Etherlink's commitment to its state.
+
 1. When the commitment that contains the transaction is cemented on layer 1, anyone can run the transaction by running the Octez client `execute outbox message` command.
 
 1. The helper contract receives the ticket and address and stores the address.

--- a/docs/building-on-etherlink/endpoint-support.md
+++ b/docs/building-on-etherlink/endpoint-support.md
@@ -487,10 +487,6 @@ For examples of using these ethers.js methods, see [Using ethers.js](/building-o
       <td>Not Supported</td>
     </tr>
     <tr>
-      <td>Native Token Decimals</td>
-      <td>18</td>
-    </tr>
-    <tr>
       <td>Fee Structure</td>
       <td>**Post London** (Fee market is not implemented yet, but the rollup supports EIP-1559 transaction types); see <a href="/network/fees">Fee structure</a></td>
     </tr>

--- a/docs/get-started/network-information.mdx
+++ b/docs/get-started/network-information.mdx
@@ -64,6 +64,10 @@ or subscribe to a commercial [RPC provider](/tools/node-providers) plan which of
       <td><code>XTZ</code></td>
     </tr>
     <tr>
+      <td>Native token decimals</td>
+      <td>18</td>
+    </tr>
+    <tr>
       <td>Block Explorer URL</td>
       <td><a href="https://explorer.etherlink.com">https://explorer.etherlink.com</a></td>
     </tr>
@@ -127,6 +131,10 @@ or subscribe to a commercial [RPC provider](/tools/node-providers) plan which of
     <tr>
       <td>Currency Symbol (native token)</td>
       <td><code>XTZ</code></td>
+    </tr>
+    <tr>
+      <td>Native token decimals</td>
+      <td>18</td>
     </tr>
     <tr>
       <td>Block Explorer URL</td>

--- a/docs/governance/how-do-i-participate-in-governance.mdx
+++ b/docs/governance/how-do-i-participate-in-governance.mdx
@@ -50,7 +50,7 @@ You need the address of the correct governance contract (and sometimes the addre
 ## Setting up an Etherlink voting key
 
 For convenience, Tezos bakers can use a voting key to vote on Etherlink proposals instead of using their baking key directly.
-Using a voting key can be more convenient than using your voting key because you don't have to retrieve the baking key from your baking setup to be able to vote on Etherlink governance.
+Using a voting key can be more convenient than using your baking key because you don't have to retrieve the baking key from your baking setup to be able to vote on Etherlink governance.
 
 You can set any Tezos layer 1 account as your voting key, so you can use an existing account or create an account to be the voting key.
 The voting key has no special built-in privileges in Etherlink; it is merely an account used to authenticate on the governance contracts.

--- a/docs/network/architecture.md
+++ b/docs/network/architecture.md
@@ -139,7 +139,7 @@ The source of truth of what Etherlink transactions are final is the state of the
 They catch any misbehavior by the sequencer or other actors, accept only valid transactions, and challenge questionable behavior.
 As described in [Refutation periods](https://docs.tezos.com/architecture/smart-rollups#refutation-periods) on docs.tezos.com, Smart Rollup nodes have two weeks to challenge commitments made about the state of a Smart Rollup, although they usually challenge any questionable state as soon as possible.
 
-Therefore, an Etherlink transaction is truly finalized two weeks after the block is it in has been published to Tezos layer 1.
+Therefore, an Etherlink transaction is truly finalized two weeks after the block it is in has been published to Tezos layer 1.
 At this point, it is permanently part of the state of the Etherlink Smart Rollup and of Tezos.
 
 However, Etherlink is set up so users can be confident that transactions are irreversible much sooner than that.

--- a/docs/network/operators.md
+++ b/docs/network/operators.md
@@ -14,6 +14,7 @@ These organizations currently run Etherlink Smart Rollup nodes in operator mode 
 
 - [The Tezos Foundation](https://tezos.foundation/)
 - [Zeeve](https://www.zeeve.io)
+- [Exaion](https://exaion.edf.fr/)
 
 You can look up the current Smart Rollup node operators by checking the accounts that currently have bond set so they can post commitments for the Etherlink Smart Rollup, such as on the TzKT block explorer: https://tzkt.io/sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf/bondholders.
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -426,7 +426,7 @@ background-color: #1B1B1B !important;
   }
 }
 .table-of-contents .table-of-contents__link:hover, .table-of-contents .table-of-contents__link--active {
-  color: #38FF9C;
+  color: #28B56F !important;
 }
 
 /* hide next and previous */


### PR DESCRIPTION
A few typos, plus I fixed the formatting so the active TOC section would appear highlighted:
<img width="310" height="451" alt="Screenshot 2025-08-20 at 2 39 18 PM" src="https://github.com/user-attachments/assets/7fcf68f4-0f24-4459-98b9-807c7cf6c79c" />
