### PR TITLE
Clarify that voting key can be any key

### DIFF
--- a/docs/governance/how-do-i-participate-in-governance.mdx
+++ b/docs/governance/how-do-i-participate-in-governance.mdx
@@ -50,7 +50,9 @@ You need the address of the correct governance contract (and sometimes the addre
 ## Setting up an Etherlink voting key
 
 For convenience, Tezos bakers can use a voting key to vote on Etherlink proposals instead of using their baking key directly.
-You can set any account as your voting key, so you can use an existing account or create an account to be the voting key.
+Using a voting key can be more convenient than using your voting key because you don't have to retrieve the baking key from your baking setup to be able to vote on Etherlink governance.
+
+You can set any Tezos layer 1 account as your voting key, so you can use an existing account or create an account to be the voting key.
 The voting key has no special built-in privileges in Etherlink; it is merely an account that you assign voting rights to.
 Bakers can change their Etherlink voting keys at any time, and changes take effect immediately.
 

--- a/docs/governance/how-do-i-participate-in-governance.mdx
+++ b/docs/governance/how-do-i-participate-in-governance.mdx
@@ -124,7 +124,7 @@ octez-client call KT1Ut6kfrTV9tK967tDYgQPMvy9t578iN7iH from <MY_BAKER> \
 Then, run this command to claim the voting rights for the specified contracts, which is just like the previous command to claim voting rights:
 
 ```bash
-octez-client call KT1Ut6kfrTV9tK967tDYgQPMvy9t578iN7iH <MY_VOTING_KEY> \
+octez-client call KT1Ut6kfrTV9tK967tDYgQPMvy9t578iN7iH from <MY_VOTING_KEY> \
   --entrypoint claim_voting_rights \
   --arg '"<MY_BAKER>"'
 ```

--- a/docs/governance/how-do-i-participate-in-governance.mdx
+++ b/docs/governance/how-do-i-participate-in-governance.mdx
@@ -50,6 +50,8 @@ You need the address of the correct governance contract (and sometimes the addre
 ## Setting up an Etherlink voting key
 
 For convenience, Tezos bakers can use a voting key to vote on Etherlink proposals instead of using their baking key directly.
+You can set any account as your voting key, so you can use an existing account or create an account to be the voting key.
+The voting key has no special built-in privileges in Etherlink; it is merely an account that you assign voting rights to.
 Bakers can change their Etherlink voting keys at any time, and changes take effect immediately.
 
 :::note

--- a/docs/governance/how-do-i-participate-in-governance.mdx
+++ b/docs/governance/how-do-i-participate-in-governance.mdx
@@ -53,7 +53,7 @@ For convenience, Tezos bakers can use a voting key to vote on Etherlink proposal
 Using a voting key can be more convenient than using your voting key because you don't have to retrieve the baking key from your baking setup to be able to vote on Etherlink governance.
 
 You can set any Tezos layer 1 account as your voting key, so you can use an existing account or create an account to be the voting key.
-The voting key has no special built-in privileges in Etherlink; it is merely an account that you assign voting rights to.
+The voting key has no special built-in privileges in Etherlink; it is merely an account used to authenticate on the governance contracts.
 Bakers can change their Etherlink voting keys at any time, and changes take effect immediately.
 
 :::note


### PR DESCRIPTION
Based on feedback, clarify that the voting key has no enshrined meaning and that you can use an existing key or generate a new key to be your voting key. Also clarify why you'd want to use one instead of the baking key.