### PR TITLE
Fix layout shift when search on ehterlink docs website

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -96,7 +96,7 @@ html {
 body {
   background-color: #101010;
   max-width: 1440px;
-  margin: auto;
+  margin: auto !important;
   padding: 0px 50px;
 }
 @media (max-width: 996px) {


### PR DESCRIPTION
Why this fix: we add `!important` to `margin: auto` to ensure the layout always centred

[linear ticket](https://linear.app/tezos/issue/ETH-69/layout-shift-when-search-on-ehterlink-docs-website)