### PR TITLE
chore: remove duplicate line in network/architecture

### DIFF
--- a/docs/network/architecture.md
+++ b/docs/network/architecture.md
@@ -42,8 +42,6 @@ However, to protect the system from censorship and any other problems with the s
 The sequencer is an instance of the `octez-evm-node` binary running in sequencer mode.
 Only one account can run the sequencer; see [Sequencer governance](/governance/how-is-etherlink-governed#sequencer-governance).
 
-The sequencer is an instance of the `octez-evm-node` binary running in sequencer mode.
-
 ## Nodes
 
 Etherlink relies on three types of nodes, with instances of each type running in different modes:


### PR DESCRIPTION
This PR removes the duplicate line from network architecture docs.

The content of [L#45](https://github.com/etherlinkcom/docs/blob/f4a1c9ae1ea42d6c261ddbaee5399ed8a674531a/docs/network/architecture.md?plain=1#L45) is already present at [L#42](https://github.com/etherlinkcom/docs/blob/f4a1c9ae1ea42d6c261ddbaee5399ed8a674531a/docs/network/architecture.md?plain=1#L42)

<img width="609" height="197" alt="image" src="https://github.com/user-attachments/assets/6ed5e2c8-3fd0-4474-9362-2d960a315953" />
