### PR TITLE
Sequencer to be run by Optimistic labs

### DIFF
--- a/docs/network/operators.md
+++ b/docs/network/operators.md
@@ -33,4 +33,4 @@ These features give Etherlink users two important checks on the sequencer operat
 - The delayed inbox ensures that if the sequencer does not include transactions, Etherlink users can force transactions to be included
 - If the sequencer does not operate efficiently or fairly, Etherlink users through Tezos bakers can vote the operator out
 
-The sequencer is currently run by Optimistic labs, whose address on Etherlink is [0x3b1885eec759c22c878e12c84fac33b3b9d153e4](https://explorer.etherlink.com/address/0x3b1885eec759c22c878e12c84fac33b3b9d153e4).
+The sequencer is currently run by Optimistic labs, whose address on Etherlink is [0x3b1885eec759c22c878e12c84fac33b3b9d153e4](https://explorer.etherlink.com/address/0x3b1885eec759c22c878e12c84fac33b3b9d153e4), in technical partnership with Nomadic Labs and TriliTech.

--- a/docs/network/operators.md
+++ b/docs/network/operators.md
@@ -34,4 +34,4 @@ These features give Etherlink users two important checks on the sequencer operat
 - The delayed inbox ensures that if the sequencer does not include transactions, Etherlink users can force transactions to be included
 - If the sequencer does not operate efficiently or fairly, Etherlink users through Tezos bakers can vote the operator out
 
-The sequencer is currently run by [MIDL.dev](http://midl.dev/), whose address on Etherlink is [0xCF02B9Ca488f8F6F4E28e37AA1bDD16b3F1b2aD8](https://explorer.etherlink.com/address/0xCF02B9Ca488f8F6F4E28e37AA1bDD16b3F1b2aD8).
+The sequencer is currently run by Optimistic labs, whose address on Etherlink is [0x3b1885eec759c22c878e12c84fac33b3b9d153e4](https://explorer.etherlink.com/address/0x3b1885eec759c22c878e12c84fac33b3b9d153e4).

--- a/docs/network/operators.md
+++ b/docs/network/operators.md
@@ -13,7 +13,6 @@ Honest Smart Rollup nodes can catch any misbehavior by other nodes by refuting t
 These organizations currently run Etherlink Smart Rollup nodes in operator mode to post and defend commitments for the current state of Etherlink:
 
 - [The Tezos Foundation](https://tezos.foundation/)
-- [MIDL.dev](http://midl.dev/)
 - [Zeeve](https://www.zeeve.io)
 
 You can look up the current Smart Rollup node operators by checking the accounts that currently have bond set so they can post commitments for the Etherlink Smart Rollup, such as on the TzKT block explorer: https://tzkt.io/sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf/bondholders.


### PR DESCRIPTION
The sequencer vote met proposal threshold, so this doc is in preparation if the vote passes.

TODOs:

- [ ] Get a web site address for Optimistic Labs
- [x] Do we need to remove MIDL from the list of entities running Smart Rollup notes earlier on this page? -- Yes
- [x] Is Optimistic Labs going to run a Smart Rollup node in addition to the sequencer? -- Not at this time, maybe eventually