### PR TITLE
Add CMC requirement to bridging FA tokens page

### DIFF
--- a/docs/bridging/bridging-fa.md
+++ b/docs/bridging/bridging-fa.md
@@ -40,7 +40,7 @@ You can set up your own UI to call the bridging contracts using any Tezos and EV
 You can also send a request to the Etherlink team to add your token to the bridge UI at https://bridge.etherlink.com/tezos.
 To request that your FA token be added to the bridge UI, fill out this request form: https://tt-tezos.typeform.com/to/qHTs7IUD.
 
-The form requires information about the token and the bridging contracts.
+The form requires information about the token and the bridging contracts:
 
 - The address of the FA token contract on Tezos
 - The address of the ticketer contract on Tezos

--- a/docs/bridging/bridging-fa.md
+++ b/docs/bridging/bridging-fa.md
@@ -40,12 +40,13 @@ You can set up your own UI to call the bridging contracts using any Tezos and EV
 You can also send a request to the Etherlink team to add your token to the bridge UI at https://bridge.etherlink.com/tezos.
 To request that your FA token be added to the bridge UI, fill out this request form: https://tt-tezos.typeform.com/to/qHTs7IUD.
 
-The form requires information about the token and the bridging contracts:
+The form requires information about the token and the bridging contracts.
 
 - The address of the FA token contract on Tezos
 - The address of the ticketer contract on Tezos
 - The address of the token bridge helper contract on Tezos
 - The address of the ERC-20 proxy contract on Etherlink
+- CoinMarketCap URL for the token
 - The name of the token
 - The ticker symbol for the token
 - The number of decimal places used in the token quantity
@@ -55,4 +56,4 @@ The form requires information about the token and the bridging contracts:
 
 You can get information about the bridging contracts from the response messages from the [bridging tool](https://github.com/baking-bad/etherlink-bridge) and from block explorers.
 
-After you submit the form, the team that manages the Etherlink bridge UI reviews it and adds it to the UI if they approve it.
+After you submit the form, the team that manages the Etherlink bridge UI reviews it and adds it to the UI if they approve it. The token must be listed at CoinMarketCap as an additional condition of approval.


### PR DESCRIPTION
The requirement to provide a CMC URL is part of the typeform used to request the Etherlink team to add the token to the bridge UI