### PR TITLE
docs: add Curve Finance, Hanji, and Oku Trade to DEX list on Exchanges page

### DIFF
--- a/docs/tools/exchanges.md
+++ b/docs/tools/exchanges.md
@@ -12,6 +12,12 @@ These centralized exchanges allow users and dApps to trade XTZ with other crypto
 
 These decentralized exchanges allow users and dApps to trade XTZ with other cryptocurrencies:
 
+- [Curve Finance](https://www.curve.finance/dex/etherlink/pools/)
+
+- [Hanji](https://hanji.io/)
+
+- [Oku Trade](https://oku.trade/?inputChain=etherlink)
+
 - [IguanaDEX](https://www.iguanadex.com/?chain=etherlink)
 
 :::note


### PR DESCRIPTION
### PR description
- **Summary**: Adds three decentralized exchanges to the Etherlink Exchanges documentation to improve discoverability of on-chain trading options.
- **Changes**:
  - Update `docs/tools/exchanges.md` to include:
    - Curve Finance: `https://www.curve.finance/dex/etherlink/pools/`
    - Hanji: `https://hanji.io/`
    - Oku Trade: `https://oku.trade/?inputChain=etherlink`
- **Why**: Keeps the DEX list current and helpful for users seeking Etherlink-compatible trading venues.
- **How to review**:
  - Open the Exchanges page and verify the three new links appear under the decentralized exchanges section.
  - Confirm each link resolves correctly.

**Optional:**
- **Follow-up**: The MEXC entry currently links to Gate.io; consider correcting to `https://www.mexc.com/` in a separate edit.