### PR TITLE
Override basic bash formatting to highlight variables

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -604,3 +604,12 @@ article img {
     width: 100%;
   }
 }
+
+/* Override color for <VARIABLES> in bash codeblocks */
+/* See src/theme/languages/prism-bash.js */
+.language-bash .token.variable,
+.language-sh .token.variable,
+.language-shell .token.variable {
+  color: var(--ifm-color-primary) !important;
+  font-style: inherit !important;
+}

--- a/src/theme/languages/prism-bash.js
+++ b/src/theme/languages/prism-bash.js
@@ -1,0 +1,16 @@
+(function (Prism) {
+
+  // Highlight blocks like <PLACEHOLDER> or <ALIAS|ADDRESS>
+  // But not <A B>
+  const placeholderRegex = new RegExp("<[\\w\|]+>", "gm");
+
+  const languageBase = {
+    'variable': {
+      pattern: placeholderRegex,
+    },
+  };
+
+  Prism.languages.bash = languageBase;
+  Prism.languages.sh = languageBase;
+  Prism.languages.shell = languageBase;
+}(Prism));

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -1,0 +1,27 @@
+import siteConfig from '@generated/docusaurus.config';
+// Swizzled via:
+// npm run swizzle @docusaurus/theme-classic prism-include-languages
+export default function prismIncludeLanguages(PrismObject) {
+  const {
+    themeConfig: {prism},
+  } = siteConfig;
+  const {additionalLanguages} = prism;
+  // Prism components work on the Prism instance on the window, while prism-
+  // react-renderer uses its own Prism instance. We temporarily mount the
+  // instance onto window, import components to enhance it, then remove it to
+  // avoid polluting global namespace.
+  // You can mutate PrismObject: registering plugins, deleting languages... As
+  // long as you don't re-assign it
+  globalThis.Prism = PrismObject;
+  additionalLanguages.forEach((lang) => {
+    // if (lang === 'php') {
+    //   // eslint-disable-next-line global-require
+    //   require('prismjs/components/prism-markup-templating.js');
+    // }
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(`prismjs/components/prism-${lang}`);
+  });
+
+  require(`./languages/prism-bash`);
+  delete globalThis.Prism;
+}


### PR DESCRIPTION
As in https://gitlab.com/tezos/docs/-/merge_requests/52, let's highlight the `<PLACEHOLDERS>` that we use in the docs. This PR overrides the default bash formatter. This affects only fenced code blocks, not inline code blocks as you can see in  these pictures:

Before:
<img width="612" height="490" alt="Screenshot 2025-08-20 at 9 06 39 AM" src="https://github.com/user-attachments/assets/6b4c86f2-131c-4e01-88d7-889c63333c8d" />


After:

<img width="562" height="463" alt="Screenshot 2025-08-20 at 9 07 13 AM" src="https://github.com/user-attachments/assets/9cad14a4-8c38-4ff4-bfe1-0ad6c548c759" />
