### PR TITLE
Fix link checker

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -51,15 +51,15 @@ jobs:
         working-directory: doclib
 
       - name: Image links check
-        run: npm run imageLinks -- --baseFolder=.. --imageFolder=static --docFiles=${{ needs.checkChangedFiles.outputs.files }} --reporter mocha-junit-reporter --reporter-options mochaFile=imageLinks.xml|| FAILED=1
+        run: npm run imageLinks -- --baseFolder=.. --imageFolder=static --docFiles=${{ needs.checkChangedFiles.outputs.files }} --reporter mocha-junit-reporter --reporter-options mochaFile=imageLinks.xml || FAILED=1
         working-directory: doclib
 
       - name: Unused images check
-        run: npm run usedImages -- --baseFolder=.. --docFiles=docs --imageFolder=static --ignoreImages=img/site --reporter mocha-junit-reporter --reporter-options mochaFile=usedImages.xml|| FAILED=1
+        run: npm run usedImages -- --baseFolder=.. --docFiles=docs --imageFolder=static --ignoreImages=img/site --reporter mocha-junit-reporter --reporter-options mochaFile=usedImages.xml || FAILED=1
         working-directory: doclib
 
       - name: Dependency proposer
-        run: npm run proposeDependencies -- --baseFolder=.. --docFiles=${{ needs.checkChangedFiles.outputs.files }} --major --reporter mocha-junit-reporter --reporter-options mochaFile=proposedDependencies.xml|| FAILED=1
+        run: npm run proposeDependencies -- --baseFolder=.. --docFiles=${{ needs.checkChangedFiles.outputs.files }} --major --reporter mocha-junit-reporter --reporter-options mochaFile=proposedDependencies.xml || FAILED=1
         working-directory: doclib
 
       - name: log result

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -47,7 +47,7 @@ jobs:
       # - Pass the changed files as a comma-separated list
 
       - name: External link and anchor check
-        run: npm run checkExternalLinks -- --baseFolder=.. --docFiles=${{ needs.checkChangedFiles.outputs.files }} --reporter mocha-junit-reporter --reporter-options mochaFile=../externalLinks.xml || FAILED=1
+        run: npm run checkExternalLinks -- --baseFolder=.. --docFiles=${{ needs.checkChangedFiles.outputs.files }} --reporter mocha-junit-reporter --reporter-options mochaFile=externalLinks.xml || FAILED=1
         working-directory: doclib
 
       - name: Image links check

--- a/docs/building-on-etherlink/transactions.md
+++ b/docs/building-on-etherlink/transactions.md
@@ -284,6 +284,13 @@ run();
 :::note
 
 Instant Confirmations are an experimental feature.
+As such, it has to be enabled by adding to the node configuration file:
+
+```json
+"experimental_features": {
+  "preconfirmation_stream_enabled": true
+}
+```
 
 :::
 

--- a/docs/building-on-etherlink/websockets.md
+++ b/docs/building-on-etherlink/websockets.md
@@ -169,6 +169,13 @@ See the documentation for your WebSocket client library for how to manage the co
 :::note
 
 Instant Confirmations are an experimental feature.
+As such, it has to be enabled by adding to the node configuration file:
+
+```json
+"experimental_features": {
+  "preconfirmation_stream_enabled": true
+}
+```
 
 :::
 


### PR DESCRIPTION
After merging #414 the test reports are available in the Checks tab for image links and such, but not for external links.
For the latter, the test is done, but the results are not included in the Mocha report.

See https://github.com/etherlinkcom/docs/actions/runs/21404745598 for an example of incomplete Mocha report containing results for: image links, proposed dependencies, and (un)used images, but excluding external links. The latter are however tested as can be seen by clicking on `tests` in the left menu, taking you to https://github.com/etherlinkcom/docs/actions/runs/21404745598/job/61625369537 where you can see that external link tests have been run, along the tests for image links, proposed dependencies, and (un)used images.

I assume the external links results are missing because their result is not within the `doclib/` folder from which artifacts are saved, but rather in the parent directory; this is unlike the other artifact, that are saved correctly.

Solution: move the external link report under `doclib/`, like for all the other tests.

Test: push a dummy commit changes a text page to trigger the tests, and compare the Mocha report (https://github.com/etherlinkcom/docs/actions/runs/23351152225) to the example above.
See that there is a new table `doclib/externalinks.xml`.