### PR TITLE
fast upgrade 6.4

### DIFF
--- a/docs/governance/how-is-etherlink-governed.md
+++ b/docs/governance/how-is-etherlink-governed.md
@@ -149,7 +149,7 @@ A separate sequencer governance contract handles the selection process for Ether
 Similar to the kernel governance processes, the sequencer voting process has Proposal, Promotion, and Cooldown periods.
 In this process, bakers propose and vote on the account that operates the sequencer.
 
-The lengths of the periods are stored in the [sequencer governance contract](https://better-call.dev/mainnet/KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98).
+The lengths of the periods are stored in the [sequencer governance contract](https://better-call.dev/mainnet/KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh).
 This table shows the period lengths as of the Ebisu Etherlink update and the Tezos Seoul protocol:
 
 Period | Length | Approximate time

--- a/docs/governance/overview.mdx
+++ b/docs/governance/overview.mdx
@@ -45,7 +45,7 @@ You need the address of the correct governance contract (and sometimes the addre
 </tr>
 <tr>
 <td>Sequencer operator</td>
-<td><InlineCopy code="KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98" href="https://better-call.dev/mainnet/KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98" abbreviate="6,4"></InlineCopy></td>
+<td><InlineCopy code="KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh" href="https://better-call.dev/mainnet/KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh" abbreviate="6,4"></InlineCopy></td>
 </tr>
 <tr>
 <td>Voting keys</td>

--- a/docs/governance/sequencer-upgrades.md
+++ b/docs/governance/sequencer-upgrades.md
@@ -15,7 +15,7 @@ For example, this Octez client command calls this view for the kernel governance
 
 ```bash
 octez-client -E https://mainnet.ecadinfra.com \
-  run view get_voting_state on contract KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98
+  run view get_voting_state on contract KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh
 ```
 
 The view returns information about the current governance period.
@@ -28,7 +28,7 @@ You can also subscribe to the `voting_finished` event to be notified when the Pr
 To propose an account to be the sequencer operator, bakers can call the `new_proposal` entrypoint of the governance contract during the Proposal period:
 
 ```bash
-octez-client transfer 0 from my_wallet to KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98 \
+octez-client transfer 0 from my_wallet to KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh \
   --entrypoint new_proposal \
   --arg 'Pair "<PUBLIC_KEY>" <L2_ADDRESS>'
 ```
@@ -43,7 +43,7 @@ The command takes these parameters:
 For example:
 
 ```bash
-octez-client call KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98 from my_wallet \
+octez-client call KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh from my_wallet \
   --entrypoint new_proposal \
   --arg 'Pair "<PUBLIC_KEY>" <L2_ADDRESS>'
 ```
@@ -53,7 +53,7 @@ To upvote a proposed sequencer operator during a Proposal period, go to the [gov
 As an alternative, call the `upvote_proposal` entrypoint with the same parameters as the `new_proposal` entrypoint:
 
 ```bash
-octez-client call KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98 from my_wallet \
+octez-client call KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh from my_wallet \
   --entrypoint upvote_proposal \
   --arg 'Pair "<PUBLIC_KEY>" <L2_ADDRESS>'
 ```
@@ -67,7 +67,7 @@ When a proposal is in the Promotion period, you can vote for or against it by go
 As an alternative, you can vote for or against it or pass on voting by calling the `vote` entrypoint of the governance contract:
 
 ```bash
-octez-client call KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98 from my_wallet \
+octez-client call KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh from my_wallet \
   --entrypoint "vote" --arg '"yea"'
 ```
 
@@ -80,7 +80,7 @@ The command takes these parameters:
 For example:
 
 ```bash
-octez-client call KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98 from tz1RLPEeMxbJYQBFbXYw8WHdXjeUjnG5ZXNq \
+octez-client call KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh from tz1RLPEeMxbJYQBFbXYw8WHdXjeUjnG5ZXNq \
   --entrypoint "vote" --arg '"yea"'
 ```
 
@@ -89,7 +89,7 @@ octez-client call KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98 from tz1RLPEeMxbJYQBFbXYw
 After a proposed account wins a vote, any account can trigger the change and enable that account to run the sequencer by calling the governance contract's `trigger_committee_upgrade` entrypoint:
 
 ```bash
-octez-client call KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98 from my_wallet \
+octez-client call KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh from my_wallet \
   --entrypoint "trigger_committee_upgrade" \
   --arg '"sr1Ghq66tYK9y3r8CC1Tf8i8m5nxh8nTvZEf"'
 ```

--- a/docs/governance/voting-key.md
+++ b/docs/governance/voting-key.md
@@ -79,7 +79,7 @@ As a result, the voting key can vote on those contracts but not on the kernel fa
 ```bash
 octez-client call KT1Ut6kfrTV9tK967tDYgQPMvy9t578iN7iH from <MY_BAKER> \
   --entrypoint propose_voting_key \
-  --arg '(Pair "<MY_VOTING_KEY>" True (Some { "KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98" ; "KT1AXRU3wLc87WNhLhVGrgqDGubLACUMUgPb" }))'
+  --arg '(Pair "<MY_VOTING_KEY>" True (Some { "KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh" ; "KT1AXRU3wLc87WNhLhVGrgqDGubLACUMUgPb" }))'
 ```
 
 Then, to claim voting rights, go to the [governance web site](https://governance.etherlink.com), connect your voting key with the **Connect** button at the top right of the page, and use the connection dialog to claim rights.
@@ -111,7 +111,7 @@ For example, from the code of the contract you can see that the parameter to pas
 This command compiles an expression of this CameLIGO type to Michelson to propose rights for two contracts:
 
 ```bash
-ligo compile expression cameligo '("<MY_VOTING_KEY>" : address), True, (Some (Set.literal [("KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98" : address); ("KT1AXRU3wLc87WNhLhVGrgqDGubLACUMUgPb" : address)]) : (address set) option)'
+ligo compile expression cameligo '("<MY_VOTING_KEY>" : address), True, (Some (Set.literal [("KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh" : address); ("KT1AXRU3wLc87WNhLhVGrgqDGubLACUMUgPb" : address)]) : (address set) option)'
 ```
 
 You can use the result as the parameter to pass to the `propose_voting_key` entrypoint.
@@ -120,7 +120,7 @@ Here is the result of the command:
 ```michelson
 (Pair "<MY_VOTING_KEY>"
       True
-      (Some { "KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98" ;
+      (Some { "KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh" ;
               "KT1AXRU3wLc87WNhLhVGrgqDGubLACUMUgPb" }))
 ```
 
@@ -129,7 +129,7 @@ Here is the resulting `octez-client` command:
 ```bash
 octez-client call KT1Ut6kfrTV9tK967tDYgQPMvy9t578iN7iH from <MY_BAKER> \
   --entrypoint propose_voting_key \
-  --arg '(Pair "<MY_VOTING_KEY>" True (Some { "KT1AXRU3wLc87WNhLhVGrgqDGubLACUMUgPb" ; "KT1VGyd2cRSHoDnxDnSuqGJD3mL8DzcVqX98" }))'
+  --arg '(Pair "<MY_VOTING_KEY>" True (Some { "KT1AXRU3wLc87WNhLhVGrgqDGubLACUMUgPb" ; "KT1KiVz8ZpHo3HpE1GCP5HLgywPDRwVUkCFh" }))'
 ```
 :::
 

--- a/docs/progress/upgrades.md
+++ b/docs/progress/upgrades.md
@@ -149,6 +149,12 @@ The Etherlink 6.3 upgrade went live on 16 May 2026 through the fast kernel gover
 
 For more information, see [Announcing Etherlink 6.3: a security bugfix for Farfadet](https://forum.tezosagora.org/t/announcing-etherlink-6-3-a-security-bugfix-for-farfadet/7068).
 
+## Etherlink 6.4
+
+The Etherlink 6.4 upgrade went live on 11 June 2026 through the fast kernel governance process and addressed different issues identified after the activation of Etherlink 6.3 during internal stress-testing and audit campaigns.
+
+For more information, see [Announcing Etherlink 6.4: a security and liveness hardening for Farfadet](https://forum.tezosagora.org/t/announcing-etherlink-6-4-a-security-and-liveness-hardening-for-farfadet/7092).
+
 ## Changelog
 
 For full details about changes to Etherlink, see [Changelogs](/progress/changelogs).

--- a/docs/progress/upgrades.md
+++ b/docs/progress/upgrades.md
@@ -18,7 +18,7 @@ For more information, see [The First Regular Upgrade for Etherlink: One Step Clo
 ## Etherlink 2 (Bifröst)
 
 The 2.0 upgrade to the Etherlink kernel went live on Etherlink Mainnet on 7 November 2024.
-It adds support for bridging [FA tokens from Tezos layer 1](https://docs.tezos.com/architecture/tokens#token-standards) to ERC-20 tokens on Etherlink and support for the callTracer tracer, which makes it possible for third-party tools like the Blockscout block explorer to index Etherlink transactions and for applications to trace transactions as described in [Tracing transactions](/building-on-etherlink/transactions#tracing-transactions).
+It adds support for bridging [FA tokens from Tezos layer 1](/architecture/tokens#token-standards) to ERC-20 tokens on Etherlink and support for the callTracer tracer, which makes it possible for third-party tools like the Blockscout block explorer to index Etherlink transactions and for applications to trace transactions as described in [Tracing transactions](/building-on-etherlink/transactions#tracing-transactions).
 For more information, see [Announcing Bifröst: a 2nd upgrade proposal for Etherlink Mainnet](https://medium.com/@etherlink/announcing-bifr%C3%B6st-a-2nd-upgrade-proposal-for-etherlink-mainnet-ef1a7cf9715f).
 
 ## Etherlink 3 (Calypso)
@@ -42,7 +42,7 @@ On 12 April 2025, the 3.1 security upgrade went live on Etherlink Mainnet, in Et
 This upgrade improves error handling of FA bridging transactions, which hardens the Etherlink sequencer against potential DDOS attacks.
 This upgrade includes only a security patch for the Calypso kernel and no other changes.
 
-This upgrade was carried out through Etherlink’s [security governance process](https://docs.etherlink.com/governance/how-is-etherlink-governed#security-governance).
+This upgrade was carried out through Etherlink’s [security governance process](/governance/how-is-etherlink-governed#security-governance).
 
 For more information, see [Calypso2: A security upgrade to harden the Etherlink sequencer and FA bridge](https://research-development.nomadic-labs.com/etherlink-calypso2-upgrade.html).
 

--- a/docs/progress/upgrades.md
+++ b/docs/progress/upgrades.md
@@ -151,7 +151,9 @@ For more information, see [Announcing Etherlink 6.3: a security bugfix for Farfa
 
 ## Etherlink 6.4
 
-The Etherlink 6.4 upgrade went live on 11 June 2026 through the fast kernel governance process and addressed different issues identified after the activation of Etherlink 6.3 during internal stress-testing and audit campaigns.
+The Etherlink 6.4 upgrade went live on 11 June 2026 through the fast kernel governance process and addressed two issues identified after the activation of Etherlink 6.3 during internal stress-testing and audit campaigns, namely:
+- Kernel hardening: Etherlink 6.4 hardens the delayed inbox, addressing flaws that could allow an attacker to disrupt the chain (including up to locking bridged assets in the worst case).
+- Sequencer governance contract upgrade: in the aftermath of the Etherlink 6.3, we discovered that the intended sequencer governance contract was incorrectly deployed. Etherlink 6.4 corrects this issue by tying the kernel to the correct governance contract on Tezos L1.
 
 For more information, see [Announcing Etherlink 6.4: a security and liveness hardening for Farfadet](https://forum.tezosagora.org/t/announcing-etherlink-6-4-a-security-and-liveness-hardening-for-farfadet/7092).
 


### PR DESCRIPTION
Update the documentation following the fast 6.4 kernel upgrade:
- mention the upgrade in the doc changelog
- update the sequencer governance contract address